### PR TITLE
Unify some variables in cpu.c and cpu_m68k.asm

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -102,21 +102,6 @@ extern UBYTE CPU_IRQ;
 #error cpu_m68k.asm does not support disassembling the code while it is executed
 #endif
 
-void CPU_Initialise(void)
-{
-	CPU_INIT();
-}
-
-void CPU_GetStatus(void)
-{
-	CPU_GET();
-}
-
-void CPU_PutStatus(void)
-{
-	CPU_PUT();
-}
-
 #else /* FALCON_CPUASM */
 
 /* Windows headers define it */
@@ -2386,10 +2371,6 @@ void CPU_GO(int limit)
 	}
 
 	UPDATE_GLOBAL_REGS;
-}
-
-void CPU_Initialise(void)
-{
 }
 
 #endif /* FALCON_CPUASM */

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -84,11 +84,23 @@ void (*CPU_rts_handler)(void) = NULL;
 int CPU_instruction_count[256];
 #endif
 
+/* Execution history */
+#ifdef MONITOR_BREAK
+UWORD CPU_remember_PC[CPU_REMEMBER_PC_STEPS];
+UBYTE CPU_remember_op[CPU_REMEMBER_PC_STEPS][3];
+unsigned int CPU_remember_PC_curpos = 0;
+int CPU_remember_xpos[CPU_REMEMBER_PC_STEPS];
+UWORD CPU_remember_JMP[CPU_REMEMBER_JMP_STEPS];
+unsigned int CPU_remember_jmp_curpos = 0;
+#define INC_RET_NESTING MONITOR_ret_nesting++
+#else /* MONITOR_BREAK */
+#define INC_RET_NESTING
+#endif /* MONITOR_BREAK */
+
 UBYTE CPU_cim_encountered = FALSE;
+UBYTE CPU_IRQ;
 
 #ifdef FALCON_CPUASM
-
-extern UBYTE CPU_IRQ;
 
 #if defined(PAGED_MEM) || defined(PAGED_ATTRIB)
 #error cpu_m68k.asm cannot work with paged memory/attributes
@@ -190,7 +202,6 @@ UBYTE CPU_regX;
 UBYTE CPU_regY;
 UBYTE CPU_regP;						/* Processor Status Byte (Partial) */
 UBYTE CPU_regS;
-UBYTE CPU_IRQ;
 
 /* Transfer 6502 registers between global variables and local variables inside CPU_GO() */
 #define UPDATE_GLOBAL_REGS  CPU_regPC = GET_PC(); CPU_regS = S; CPU_regA = A; CPU_regX = X; CPU_regY = Y
@@ -223,19 +234,6 @@ void CPU_PutStatus(void)
 	Z = (CPU_regP & 0x02) ^ 0x02;
 	C = (CPU_regP & 0x01);
 }
-
-/* Execution history */
-#ifdef MONITOR_BREAK
-UWORD CPU_remember_PC[CPU_REMEMBER_PC_STEPS];
-UBYTE CPU_remember_op[CPU_REMEMBER_PC_STEPS][3];
-unsigned int CPU_remember_PC_curpos = 0;
-int CPU_remember_xpos[CPU_REMEMBER_PC_STEPS];
-UWORD CPU_remember_JMP[CPU_REMEMBER_JMP_STEPS];
-unsigned int CPU_remember_jmp_curpos = 0;
-#define INC_RET_NESTING MONITOR_ret_nesting++
-#else /* MONITOR_BREAK */
-#define INC_RET_NESTING
-#endif /* MONITOR_BREAK */
 
 /* Addressing modes */
 #ifdef WRAP_ZPAGE

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -16,7 +16,6 @@
 #define CPU_Z_FLAG 0x02
 #define CPU_C_FLAG 0x01
 
-void CPU_Initialise(void);		/* used in the assembler version of cpu.c only */
 void CPU_GetStatus(void);
 void CPU_PutStatus(void);
 void CPU_Reset(void);
@@ -25,12 +24,6 @@ void CPU_StateRead(UBYTE SaveVerbose, UBYTE StateVersion);
 void CPU_NMI(void);
 void CPU_GO(int limit);
 #define CPU_GenerateIRQ() (CPU_IRQ = 1)
-
-#ifdef FALCON_CPUASM
-extern void CPU_INIT(void);
-extern void CPU_GET(void);		/* put from CCR, N & Z FLAG into regP */
-extern void CPU_PUT(void);		/* put from regP into CCR, N & Z FLAG */
-#endif
 
 extern UWORD CPU_regPC;
 extern UBYTE CPU_regA;

--- a/src/falcon/cpu_m68k.asm
+++ b/src/falcon/cpu_m68k.asm
@@ -90,9 +90,8 @@ NEW_CYCLE_EXACT equ 1   ; set to 1 to use the new cycle exact CPU emulation
   xdef _CPU_NMI
   xdef _RTI
   xdef _CPU_GO
-  xdef _CPU_GET
-  xdef _CPU_PUT
-  xdef _CPU_INIT
+  xdef _CPU_GetStatus
+  xdef _CPU_PutStatus
   xref _CPU_cim_encountered
   xref _CPU_rts_handler
 
@@ -147,7 +146,7 @@ regPC
 _CPU_regPC ds.w 1  ; PC
 
 regS
-  ds.b 1
+  dc.b $01
 _CPU_regS  ds.b 1   ; stack
 
 IRQ
@@ -445,16 +444,6 @@ RMW_GETBYTE macro
   endif
   endm
 
-_CPU_INIT:
-  ifne   MONITOR_BREAK
-  moveq  #0,d0
-  move.l d0,_CPU_remember_PC_curpos
-  move.l d0,_CPU_remember_jmp_curpos
-  endif
-  moveq  #1,d0     ; set regS to page 1
-  move.b d0,regS
-  rts
-
 ;these are bit in MC68000 CCR register
 NB68  equ 3
 EB68  equ 4 ;X
@@ -644,14 +633,12 @@ ClrCFLAG macro
   clr.b  CFLAG
   endm
 
-CPUGET:
-_CPU_GET:
+_CPU_GetStatus:
   ConvertSTATUS_RegP d0
   move.b d0,_CPU_regP
   rts
 
-CPUPUT:
-_CPU_PUT:
+_CPU_PutStatus:
   move.b _CPU_regP,d0
   ConvertRegP_STATUS d0
   rts

--- a/src/falcon/cpu_m68k.asm
+++ b/src/falcon/cpu_m68k.asm
@@ -66,12 +66,12 @@ NEW_CYCLE_EXACT equ 1   ; set to 1 to use the new cycle exact CPU emulation
   xref _CPU_instruction_count
   endif
   ifne MONITOR_BREAK
-  xdef _CPU_remember_PC
-  xdef _CPU_remember_op
-  xdef _CPU_remember_PC_curpos
-  xdef _CPU_remember_xpos
-  xdef _CPU_remember_JMP
-  xdef _CPU_remember_jmp_curpos
+  xref _CPU_remember_PC
+  xref _CPU_remember_op
+  xref _CPU_remember_PC_curpos
+  xref _CPU_remember_xpos
+  xref _CPU_remember_JMP
+  xref _CPU_remember_jmp_curpos
   xref _ANTIC_break_ypos
   xref _ANTIC_ypos
   xref _MONITOR_break_addr
@@ -86,7 +86,7 @@ NEW_CYCLE_EXACT equ 1   ; set to 1 to use the new cycle exact CPU emulation
   xref _UI_crash_afterCIM
   xref _UI_Run
   endif
-  xdef _CPU_IRQ
+  xref _CPU_IRQ
   xdef _CPU_NMI
   xdef _RTI
   xdef _CPU_GO
@@ -96,30 +96,8 @@ NEW_CYCLE_EXACT equ 1   ; set to 1 to use the new cycle exact CPU emulation
   xref _CPU_rts_handler
 
   ifne MONITOR_BREAK
-
 rem_pc_steps  equ 64  ; has to be equal to REMEMBER_PC_STEPS
 rem_jmp_steps equ 16  ; has to be equal to REMEMBER_JMP_STEPS
-
-remember_PC
-_CPU_remember_PC
-  ds.w rem_pc_steps   ;REMEMBER_PC_STEPS
-remember_op:
-_CPU_remember_op
-  ds.b rem_pc_steps*3 ;[REMEMBER_PC_STEPS][3]
-remember_PC_curpos
-_CPU_remember_PC_curpos
-  ds.l 1
-remember_xpos
-_CPU_remember_xpos
-  ds.l rem_pc_steps   ;REMEMBER_PC_STEPS
-
-remember_JMP
-_CPU_remember_JMP
-  ds.w rem_jmp_steps  ;REMEMBER_JMP_STEPS
-remember_jmp_curpos
-_CPU_remember_jmp_curpos
-  ds.l 1
-
   endif
 
   even
@@ -148,10 +126,6 @@ _CPU_regPC ds.w 1  ; PC
 regS
   dc.b $01
 _CPU_regS  ds.b 1   ; stack
-
-IRQ
-_CPU_IRQ  ds.b 1
-      ds.b 1    ; dummy
 
   even
 

--- a/src/falcon/main.c
+++ b/src/falcon/main.c
@@ -37,7 +37,6 @@
 
 #include "atari.h"
 #include "binload.h"
-#include "cpu.h"
 #include "colours.h"
 #include "ui.h"
 #include "input.h"
@@ -517,8 +516,6 @@ int PLATFORM_Initialise(int *argc, char *argv[])
 	Original_Phys_base = Physbase();
 
 	key_tab = Keytbl(-1, -1, -1);
-
-	CPU_Initialise();
 
 #ifdef SOUND
 	if (!Sound_Initialise(argc, argv))
@@ -1385,7 +1382,7 @@ int main(int argc, char **argv)
 
 	/* initialise Atari800 core */
 	if (!Atari800_Initialise(&argc, argv))
-		return 3;
+		return EXIT_FAILURE;
 
 	/* main loop */
 	for (;;) {


### PR DESCRIPTION
There's really no point to have two function names with the same purpose.