### PR TITLE
Enable RMW for POKEY

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -163,7 +163,7 @@ UBYTE CPU_IRQ;
 #define RMW_GetByte(x, addr) \
 	if (MEMORY_attrib[addr] == MEMORY_HARDWARE) { \
 		x = MEMORY_HwGetByte(addr, FALSE); \
-		if ((addr & 0xef00) == 0xc000) { \
+		if ((addr & 0xed00) == 0xc000) { \
 			ANTIC_xpos--; \
 			MEMORY_HwPutByte(addr, x); \
 			ANTIC_xpos++; \
@@ -173,7 +173,7 @@ UBYTE CPU_IRQ;
 #else /* PAGED_ATTRIB */
 #define RMW_GetByte(x, addr) \
 	x = MEMORY_GetByte(addr); \
-	if ((addr & 0xef00) == 0xc000) { \
+	if ((addr & 0xed00) == 0xc000) { \
 		ANTIC_xpos--; \
 		MEMORY_PutByte(addr, x); \
 		ANTIC_xpos++; \

--- a/src/falcon/cpu_m68k.asm
+++ b/src/falcon/cpu_m68k.asm
@@ -404,7 +404,7 @@ EXE_PUTBYTE macro
 RMW_GETBYTE macro
   ifne   NEW_CYCLE_EXACT
   move.w d7,d0
-  and.w  #$ef00,d0
+  and.w  #$ed00,d0
   cmp.w  #$c000,d0
   bne.s  .normal_get
   EXE_GETBYTE


### PR DESCRIPTION
This patch enables RMW for Pokey and fixes being able to ack/reset timer 1 with a single INC IRQEN.

Contributed by Ivo van Poorten.

As seen here: https://sourceforge.net/p/atari800/mailman/message/34233143/