### PR TITLE
Add POKEY recording functionality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,7 @@ dnl Silent rules
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 WANT_IDE="yes"
+WANT_POKEYREC="yes"
 
 dnl Set a8_host...
 
@@ -1060,6 +1061,15 @@ if [[ "$WANT_IDE" = "yes" ]]; then
 fi
 AM_CONDITIONAL([WANT_IDE], test "$WANT_IDE" = "yes")
 
+A8_OPTION(pokeyrec,$WANT_POKEYREC,
+          [Provide Pokey registers recording (default=ON)],
+          POKEYREC,[Define to add Pokey registers recording.]
+         )
+if [[ "$WANT_POKEYREC" == "yes" ]]; then
+    AC_SYS_LARGEFILE
+    OBJS="$OBJS pokeyrec.o"
+fi
+
 if [[ "$a8_use_sdl" = yes ]]; then
     A8_OPTION(onscreenkeyboard,no,
               [Enable on-screen keyboard (default=OFF)],
@@ -1267,6 +1277,7 @@ echo "Using event recording?................: $WANT_EVENT_RECORDING"
 echo "Using MIO emulation?..................: $WANT_PBI_MIO"
 echo "Using Black Box emulation?............: $WANT_PBI_BB"
 echo "Using IDE emulation?..................: $WANT_IDE"
+echo "Using Pokey registers recording?......: $WANT_POKEYREC"
 echo "Interface for sound...................: $with_sound"
 if [[ "$with_sound" != no ]]; then
     echo "    Using nonlinear mixing?...........: $WANT_NONLINEAR_MIXING"

--- a/configure.ac
+++ b/configure.ac
@@ -1067,8 +1067,8 @@ A8_OPTION(pokeyrec,$WANT_POKEYREC,
          )
 if [[ "$WANT_POKEYREC" == "yes" ]]; then
     AC_SYS_LARGEFILE
-    OBJS="$OBJS pokeyrec.o"
 fi
+AM_CONDITIONAL([WANT_POKEYREC], test "$WANT_POKEYREC" = "yes")
 
 if [[ "$a8_use_sdl" = yes ]]; then
     A8_OPTION(onscreenkeyboard,no,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -107,6 +107,9 @@ endif
 if WITH_SOUND_LIBATARI800
 atari800_SOURCES += sound.c libatari800/sound.c libatari800/sound.h
 endif
+if WANT_POKEYREC
+atari800_SOURCES += pokeyrec.c pokeyrec.h
+endif
 
 
 

--- a/src/atari.c
+++ b/src/atari.c
@@ -75,6 +75,9 @@
 #ifdef IDE
 #  include "ide.h"
 #endif
+#ifdef POKEYREC
+#include "pokeyrec.h"
+#endif
 #include "pia.h"
 #include "platform.h"
 #include "pokey.h"
@@ -733,6 +736,9 @@ int Atari800_Initialise(int *argc, char *argv[])
 #ifdef IDE
 		|| !IDE_Initialise(argc, argv)
 #endif
+#ifdef POKEYREC
+		|| !POKEYREC_Initialise(argc, argv)
+#endif
 		|| !SIO_Initialise (argc, argv)
 		|| !CARTRIDGE_Initialise(argc, argv)
 		|| !CASSETTE_Initialise(argc, argv)
@@ -981,6 +987,9 @@ int Atari800_Exit(int run_monitor)
 		SIO_Exit();	/* umount disks, so temporary files are deleted */
 #ifdef IDE
 		IDE_Exit();
+#endif
+#ifdef POKEYREC
+		POKEYREC_Exit();
 #endif
 		Devices_Exit();
 #ifdef R_IO_DEVICE

--- a/src/pokey.c
+++ b/src/pokey.c
@@ -50,6 +50,10 @@
 #include "input.h"
 #include "pbi.h"
 
+#ifdef POKEYREC
+#include "pokeyrec.h"
+#endif
+
 #ifdef VOICEBOX
 #include "voicebox.h"
 #include "votraxsnd.h"
@@ -447,6 +451,10 @@ void POKEY_Frame(void)
 
 void POKEY_Scanline(void)
 {
+#ifdef POKEYREC
+    POKEYREC_Recorder();
+#endif
+
 #ifdef POKEY_UPDATE
 	pokey_update();
 #endif

--- a/src/pokeyrec.c
+++ b/src/pokeyrec.c
@@ -1,0 +1,129 @@
+/*
+ * pokeyrec.c - record pokey registers to a file
+ *
+ * Copyright (C) 2015 Ivo van Poorten
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+#include "config.h"
+#include "pokeyrec.h"
+#include "pokey.h"
+#include "log.h"
+#include "util.h"
+#include <string.h>
+#include <stdio.h>
+
+static int enabled, counter, interval;
+static char *filename = "pokeyrec.dat", *fmt = "%c";
+static FILE *fp;
+#ifdef STEREO_SOUND
+static int stereo;
+#endif
+
+static void output_pokey_values(int pokeynr) {
+    int i;
+    for (i=0; i<4; i++) {
+        fprintf(fp, fmt, POKEY_AUDF[(pokeynr*4)+i]);
+        fprintf(fp, fmt, POKEY_AUDC[(pokeynr*4)+i]);
+    }
+    fprintf(fp, fmt, POKEY_AUDCTL[pokeynr]);
+}
+
+void POKEYREC_Recorder(void) {
+    if (!enabled) return;
+
+    if (++counter == interval) {
+        counter = 0;
+        output_pokey_values(0);
+#ifdef STEREO_SOUND
+        if (stereo) output_pokey_values(1);
+#endif
+        if (fmt[1] != 'c')
+            fputc('\n', fp);
+    }
+}
+
+int POKEYREC_Initialise(int *argc, char *argv[]) {
+    int i, j;
+
+    interval = Atari800_tv_mode;
+
+    for (i = j = 1; i < *argc; i++) {
+        int available = i + 1 < *argc;
+
+        if (!strcmp(argv[i], "-pokeyrec")) {
+            enabled = 1;
+        } else if (!strcmp(argv[i], "-pokeyrec-interval")) {
+            if (!available) goto missing_argument;
+            interval = Util_sscandec(argv[++i]);
+            if (interval < 0) {
+                Log_print("Negative interval not allowed");
+                return FALSE;
+            }
+        } else if (!strcmp(argv[i], "-pokeyrec-ascii")) {
+            fmt = "%02x";
+        } else if (!strcmp(argv[i], "-pokeyrec-file")) {
+            if (!available) goto missing_argument;
+            filename = Util_strdup(argv[++i]);
+#ifdef STEREO_SOUND
+        } else if (!strcmp(argv[i], "-pokeyrec-stereo")) {
+            stereo = 1;
+#endif
+        } else {
+            if (!strcmp(argv[i], "-help")) {
+                Log_print("\t-pokeyrec                  "
+                                "Enable Pokey registers recording");
+                Log_print("\t-pokeyrec-interval <n>     "
+                                "Sampling interval in scanlines (default: %d)",
+                                                                    interval);
+                Log_print("\t-pokeyrec-ascii            "
+                                "Store ascii values (default: raw)");
+                Log_print("\t-pokeyrec-file <filename>  "
+                                "Specify output filename "
+                                                    "(default: pokeyrec.dat)");
+#ifdef STEREO_SOUND
+                Log_print("\t-pokeyrec-stereo           "
+                                "Record second Pokey, too "
+                                                    "(default: mono)");
+#endif
+            }
+            argv[j++] = argv[i];
+        }
+    }
+
+    *argc = j;
+
+    if (enabled) {
+        if (!(fp = fopen(filename, "wb"))) {
+            Log_print("Unable to open '%s' for writing", filename);
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+
+missing_argument:
+    Log_print("Missing argument for '%s'", argv[i]);
+    return FALSE;
+}
+
+void POKEYREC_Exit(void) {
+    fclose(fp);
+}

--- a/src/pokeyrec.h
+++ b/src/pokeyrec.h
@@ -1,0 +1,8 @@
+#ifndef POKEYREC_H_
+#define POKEYREC_H_
+
+void POKEYREC_Recorder(void);
+int  POKEYREC_Initialise(int *argc, char *argv[]);
+void POKEYREC_Exit(void);
+
+#endif


### PR DESCRIPTION
It supports mono and stereo recording of the first 9 Pokey registers to a file. This can be handy for recording (Turbo) Basic tunes or songs for which it is difficult to separate the player from the game.

Contributed by Ivo van Poorten.

First feature request here: https://atariage.com/forums/topic/242349-sap-type-r-recording-turbo-basic-tunes-to-sap

Published here: https://sourceforge.net/p/atari800/mailman/message/34458219/