### PR TITLE
Buffer not terminated in safe_gets()

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -711,6 +711,7 @@ static void safe_gets(char *buffer, size_t size, char const *prompt)
 		char *got = readline(prompt);
 		if (got) {
 			strncpy(buffer, got, size);
+			buffer[size-1]='\0';
 			if (*got)
 				add_history(got);
 			free(got); /* Need to free buffer allocated by readline() */


### PR DESCRIPTION
Function strncpy() doesn't terminate destination string if source string is longer than size-1.

Contributed by user 'ub880d ' on sf.net.

As seen here: https://sourceforge.net/p/atari800/patches/10/