### PR TITLE
use zlib-provided crc32 if HAVE_LIBZ is defined

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -42,6 +42,8 @@
 		table[i] = crc;
 	}
  */
+
+#ifndef HAVE_LIBZ
 static ULONG table[0x100]= {
 	0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
 	0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988, 0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91,
@@ -86,6 +88,7 @@ ULONG CRC32_Update(ULONG crc, UBYTE const *buf, unsigned int len)
 
 	return crc;
 }
+#endif
 
 int CRC32_FromFile(FILE *f, ULONG *result)
 {

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -7,7 +7,12 @@
 
 /* Compute CRC32 of LEN bytes from BUF. CRC should be set initially to
    0xffffffff. */
+#ifdef HAVE_LIBZ
+#include <zlib.h>
+#define CRC32_Update(crc, buf, len) crc32((crc), (buf), (len))
+#else
 ULONG CRC32_Update(ULONG crc, UBYTE const *buf, unsigned int len);
+#endif
 
 /* Compute CRC32 of a stream F and store it at *RESULT. Return non-zero on
    success or 0 on read error. */

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -9,7 +9,7 @@
    0xffffffff. */
 #ifdef HAVE_LIBZ
 #include <zlib.h>
-#define CRC32_Update(crc, buf, len) crc32((crc), (buf), (len))
+#define CRC32_Update(crc, buf, len) (crc32((crc) ^ 0xFFFFFFFF, (buf), (len)) ^ 0xFFFFFFFF)
 #else
 ULONG CRC32_Update(ULONG crc, UBYTE const *buf, unsigned int len);
 #endif


### PR DESCRIPTION
This has the potential to save some code/data space (up to ~1K) in the final binary, and avoid redundant implementations of the same algorithm.

~~EDIT: Doesn't seem to work quite right - I wonder why...~~

EDIT 2 (05/06/2020): Seems to work fine! However, I cannot test every case.