### PR TITLE
Add missing command line options

### DIFF
--- a/src/atari.c
+++ b/src/atari.c
@@ -770,6 +770,7 @@ int Atari800_Initialise(int *argc, char *argv[])
 #endif
 #if !defined(BASIC) && !defined(CURSES_BASIC)
 		|| !Screen_Initialise(argc, argv)
+		|| !UI_Initialise(argc, argv)
 #endif
 		/* Initialise Custom Chips */
 		|| !ANTIC_Initialise(argc, argv)

--- a/src/sdl/input.c
+++ b/src/sdl/input.c
@@ -1283,6 +1283,18 @@ int SDL_INPUT_Initialise(int *argc, char *argv[])
 			else a_m = TRUE;
 		}
 #endif /* LPTJOY */
+		else if (strcmp(argv[i], "-kbdjoy0") == 0) {
+			PLATFORM_kbd_joy_0_enabled = TRUE;
+		}
+		else if (!strcmp(argv[i], "-kbdjoy1")) {
+			PLATFORM_kbd_joy_1_enabled = TRUE;
+		}
+		else if (strcmp(argv[i], "-no-kbdjoy0") == 0) {
+			PLATFORM_kbd_joy_0_enabled = FALSE;
+		}
+		else if (!strcmp(argv[i], "-no-kbdjoy1")) {
+			PLATFORM_kbd_joy_1_enabled = FALSE;
+		}
 		else {
 			if (strcmp(argv[i], "-help") == 0) {
 				help_only = TRUE;
@@ -1295,6 +1307,11 @@ int SDL_INPUT_Initialise(int *argc, char *argv[])
 				Log_print("\t-joy0 <pathname> Select LPTjoy0 device");
 				Log_print("\t-joy1 <pathname> Select LPTjoy1 device");
 #endif /* LPTJOY */
+				Log_print("\t-kbdjoy0         enable joystick 0 keyboard emulation");
+				Log_print("\t-kbdjoy1         enable joystick 1 keyboard emulation");
+				Log_print("\t-no-kbdjoy0      disable joystick 0 keyboard emulation");
+				Log_print("\t-no-kbdjoy1      disable joystick 1 keyboard emulation");
+
 				Log_print("\t-grabmouse       Prevent mouse pointer from leaving window");
 			}
 			argv[j++] = argv[i];

--- a/src/ui.c
+++ b/src/ui.c
@@ -4219,6 +4219,55 @@ static void HotKeyHelp(void)
 }
 #endif
 
+int UI_Initialise(int *argc, char *argv[])
+{
+	int i;
+	int j;
+
+	for (i = j = 1; i < *argc; i++) {
+		int i_a = (i + 1 < *argc); /* is argument available? */
+		int a_m = FALSE; /* error, argument missing! */
+		int a_i = FALSE; /* error, argument invalid! */
+
+		if (strcmp(argv[i], "-atari_files") == 0) {
+			if (i_a) {
+				if (UI_n_atari_files_dir >= UI_MAX_DIRECTORIES)
+					Log_print("All ATARI_FILES_DIR slots used!");
+				else
+					Util_strlcpy(UI_atari_files_dir[UI_n_atari_files_dir++], argv[++i], FILENAME_MAX);
+			}
+			else a_m = TRUE;
+		}
+		else if (strcmp(argv[i], "-saved_files") == 0) {
+			if (i_a) {
+				if (UI_n_saved_files_dir >= UI_MAX_DIRECTORIES)
+					Log_print("All SAVED_FILES_DIR slots used!");
+				else
+					Util_strlcpy(UI_saved_files_dir[UI_n_saved_files_dir++], argv[++i], FILENAME_MAX);
+			}
+			else a_m = TRUE;
+		}
+		else {
+			if (strcmp(argv[i], "-help") == 0) {
+				Log_print("\t-atari_files <path>  Set default path for Atari executables");
+				Log_print("\t-saved_files <path>  Set default path for saved files");
+			}
+			argv[j++] = argv[i];
+		}
+
+		if (a_m) {
+			Log_print("Missing argument for '%s'", argv[i]);
+			return FALSE;
+		} else if (a_i) {
+			Log_print("Invalid argument for '%s'", argv[--i]);
+			return FALSE;
+		}
+	}
+	*argc = j;
+
+	return TRUE;
+}
+
 void UI_Run(void)
 {
 	static UI_tMenuItem menu_array[] = {

--- a/src/ui.h
+++ b/src/ui.h
@@ -30,6 +30,7 @@
 
 /* Three legitimate entries to UI module. */
 int UI_SelectCartType(int k);
+int UI_Initialise(int *argc, char *argv[]);
 void UI_Run(void);
 
 extern int UI_is_active;


### PR DESCRIPTION
As per issue #29, this patch adds following command line options:

- `-atari_files` (analog to `ATARI_FILES_DIR`)
- `-saved_files` (analog to `SAVED_FILES_DIR`)
- `-kbdjoy0` (analog to `SDL_JOY_0_ENABLED = 1`)
- `-kbdjoy1` (analog to `SDL_JOY_1_ENABLED = 1`)
- `-no-kbdjoy0` (analog to `SDL_JOY_0_ENABLED = 0`)
- `-no-kbdjoy1` (analog to `SDL_JOY_1_ENABLED = 0`)

@severach can you confirm this is what you had in mind? If so, we can merge this PR and consider #29 as fixed. The source tree to compile can be found at https://github.com/atari800/atari800/tree/issue29.