### PR TITLE
reformat build linux packages

### DIFF
--- a/DOC/BUILD.linux_package
+++ b/DOC/BUILD.linux_package
@@ -11,15 +11,22 @@ Ensure that you have the necessary tools installed:
 
 OBTAIN SOURCE CODE
 ==================
-Download the latest release of the source code from the Github Releases Area (https://github.com/atari800/atari800/releases).  Look for a file with a name like 'atari800-4.2.0-src.tgz'.
+Download the latest release of the source code from the Github Releases Area
+(https://github.com/atari800/atari800/releases).  Look for a file with a name
+like 'atari800-4.2.0-src.tgz'.
 
-Unzip the source code.  The contents will go into a directory called 'atari800-4.2.0' or similar.  This will be referred to in these notes as the 'atari800' directory.
+Unzip the source code.  The contents will go into a directory called
+'atari800-4.2.0' or similar.  This will be referred to in these notes as the
+'atari800' directory.
 
-Do not obtain the source code by cloning the current atari800 repository because this may have been modified since the last release and may contain partially developed and untested code.
+Do not obtain the source code by cloning the current atari800 repository
+because this may have been modified since the last release and may contain
+partially developed and untested code.
 
 COMPILE WITHOUT ERROR
 =====================
-Unzip the code and native compile it on the target machine.  Follow the instructions in the appropriate atari800/DOC file:
+Unzip the code and native compile it on the target machine.  Follow the
+instructions in the appropriate atari800/DOC file:
 
     INSTALL      - see Building the Emulator on most platforms
     BUILD.RPI    - specific instructions for the Raspberry Pi
@@ -28,13 +35,17 @@ Confirm that the compilation completes without error.
 
 UPDATE DEBIAN CHANGELOG
 =======================
-Update file 'atari800/debian/changelog'.  You can simply edit this by hand, but the system is fussy about the exact format, location of spaces etc., so it is handy to use the debchange command as follows.
+Update file 'atari800/debian/changelog'.  You can simply edit this manually,
+but the system is fussy about the exact format, location of spaces etc., so it
+is handy to use the debchange command as follows.
 
 Open a terminal on the atari800 directory.
 
     debchange
 
-Select an editor from the presented menu.  Debchange guesses a new version number and other details and enters some new lines into the log for you.  The top of the file should look something like this:
+Select an editor from the presented menu.  Debchange guesses a new version
+number and other details and enters some new lines into the log for you.  The
+top of the file should look something like this:
 
     atari800 (4.2.0-1ubuntu1) UNRELEASED; urgency=medium
 
@@ -50,34 +61,44 @@ Edit these lines as appropriate.  For example:
 
      -- Cliff Hatch <Contact via atari800-users@lists.sourceforge.net>  Sat, 04 Jul 2020 10:06:18 +0100
 
-The version number '4.2.0-1' will be used as part of the name of the package you are going to build.  If you build several releases of '4.2.0' to fix bugs, call them '4.2.0-1', '4.2.0-2', etc..
+The version number '4.2.0-1' will be used as part of the name of the package
+you are going to build.  If you build additional releases of '4.2.0' to fix
+bugs, call them '4.2.0-1', '4.2.0-2', etc..
 
-Label the release 'unstable'.  This does not mean it is actually unstable, just that you have not done exhaustive tests to prove otherwise.
+Label the release 'unstable'.  This does not mean it is actually unstable, just
+that you have not done exhaustive tests to prove otherwise.
 
-You may add additional comments if you wish, on lines beginning with two spaces and a '*'.
+You may add additional comments if you wish, on lines beginning with two spaces
+and a '*'.
 
 Set urgency to 'low', or 'medium' for major updates.
 
-Enter your name and contact details in place of the default user and computer names.
+Enter your name and contact details in place of the default user and computer
+names.
 
 ADJUST BUILD OPTIONS IN THE DEBIAN RULES FILE
 =============================================
 
 CONFIGURATION OPTIONS
 ---------------------
-The debian rules file 'atari800/debian/rules' contains the following command (split over two lines):
+The debian rules file 'atari800/debian/rules' contains the following command
+(split over two lines):
 
 	./configure \
 		 --with-video=sdl --with-sound=sdl
 
-You don't need to change this if your are building the stock SDL version.  Otherwise edit the second line to specify configuration options for the target machine.  For example, the command required for the older Raspberry Pis (0, 2 and 3) is:
+You don't need to change this if your are building the stock SDL version.
+Otherwise edit the second line to specify configuration options for the target
+machine.  For example, the command required for the older Raspberry
+Pis (0, 2 and 3) is:
 
 	./configure \
 		 --target=rpi
 
 DOCUMENTATION FILE OPTIONS
 --------------------------
-If you wish to package any special documentation relating to the target machine, add commands under this existing comment:
+If you wish to package any special documentation relating to the target
+machine, add commands under this existing comment:
 
     # Install docs in proper directory and gzip them
 
@@ -85,7 +106,8 @@ or if the files are small and don't need gzipping, put them under this comment:
 
     # These are too small to gzip
 
-For example, you might add the following command to copy README.RPI into Raspberry Pi packages: 
+For example, you might add the following command to copy README.RPI into
+Raspberry Pi packages: 
 
     cp DOC/README.RPI debian/tmp/usr/share/doc/$(P)/README.RPI
    
@@ -94,13 +116,17 @@ BUILD THE PACKAGE
 
     dpkg-buildpackage -d -B -uc -us
 
-Even though you started with a version of the source code that compiles without error, it is possible that warnings and errors may be reported at this stage.  Warnings can usually be ignored, but you will have to investigate and correct any errors.
+Even though you started with a version of the source code that compiles without
+error, it is possible that warnings and errors may be reported at this stage.
+Warnings can usually be ignored, but you will have to investigate and correct
+any errors.
 
-The above command creates three files and places them in the parent of the atari800 directory.  They will have names like these:
+The above command creates three files and places them in the parent of the
+atari800 directory.  They will have names like these:
 
-    atari800_4.2.0-1_amd64.buildinfo    - contains checksums for the .deb file and a list of dependencies.
-    atari800_4.2.0-1_amd64.changes      - changelog updates and checksums for .deb and .buildinfo files.
-    atari800_4.2.0-1_amd64.deb          - the .deb file for release.
+    atari800_4.2.0-1_amd64.buildinfo - .deb file checksums and a list of dependencies.
+    atari800_4.2.0-1_amd64.changes   - changelog update and checksums for .deb and .buildinfo.
+    atari800_4.2.0-1_amd64.deb       - the .deb file for release.
 
 'amd64' indicates the architecture of the machine that the build was done on.
 
@@ -110,7 +136,8 @@ INSTALL
 
 or
 
-<Right Click> and select the appropriate menu item, <Package Install> or <Open with GDebi Package Installer> etc..
+<Right Click> and select the appropriate menu item, <Package Install> or
+<Open with GDebi Package Installer> etc..
 
 TEST
 ====
@@ -130,11 +157,13 @@ You can unistall the package if desired with:
 
     sudo dpkg --remove atari800
 
-This removes the command and documentation, but leaves the configuration file .atari.cfg in place.
+This removes the command and documentation, but leaves the configuration file
+.atari.cfg in place.
 
 RENAME THE PACKAGE
 ==================
-The default names of packages are sometimes not very informative, in which case you may change them to anything you like.
+The default names of packages are sometimes not very informative, in which case
+you may change them to anything you like.
 
 For example, the name of the 4.2.0 Raspberry Pi 4 package was changed from
 
@@ -146,13 +175,16 @@ to
 
 DISTRIBUTION
 ============
-Send the three files created (.buildinfo, .changes and .deb) to the owner of the atari800/atari800 Git repository for general release.
+Send the three files created (.buildinfo, .changes and .deb) to the owner of
+the atari800/atari800 Git repository for general release.
 
 ISSUE A PULL REQUEST TO UPDATE THE DEBIAN CHANGELOG
 ===================================================
-Enter the new lines you created in atari800/debian/changelog into the master of this file on Git.
+Enter the new lines you created in atari800/debian/changelog into the master
+of this file on Git.
 
-This is not essential, but it keeps the record intact and confirms to anyone taking on the task of building packages that this is the current system.
+This is not essential, but it keeps the record intact and confirms to anyone
+taking on the task of building packages that this is the current system.
 
 
 


### PR DESCRIPTION
I originally wrote this file in an editor with word wrap.  This pull request is to reformat it with line length ~80 chars, to make it more readable in editors without word wrap.