### PR TITLE
video accel default

### DIFF
--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -68,7 +68,7 @@ static VIDEOMODE_resolution_t desktop_resolution;
 
 #if HAVE_OPENGL
 int SDL_VIDEO_opengl_available;
-int SDL_VIDEO_opengl = FALSE;
+int SDL_VIDEO_opengl = TRUE;
 /* Was OpenGL active previously? */
 static int currently_opengl = FALSE;
 #endif


### PR DESCRIPTION
This pull request is to fix a problem with installation on the Raspberry Pi 4.  Video acceleration is turned off by default, but the Pi 4 is not fast enough to run the emulator properly without it.  This can be put right by turning acceleration on later by hand, but it would be better if this was done automatically.

It appears that the simplest solution is to reverse the default, such that acceleration is turned on for all machines that support it, including the Pi 4.  The proposed change causes 'VIDEO_ACCEL=1' to be written into the configuration file when it is first created, instead of 'VIDEO_ACCEL=0'.  It has no other effects.  The setting can still be changed manually if required, and the options -video-accel and -no-video-accel still override the setting in the configuration file.