### PR TITLE
fix for BBSB lift not working

### DIFF
--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -1121,12 +1121,10 @@ UBYTE CARTRIDGE_BountyBob1GetByte(UWORD addr, int no_side_effects)
 		if (Atari800_machine_type == Atari800_MACHINE_5200) {
 			if (addr >= 0x4ff6 && addr <= 0x4ff9) {
 				CARTRIDGE_BountyBob1(addr);
-				return 0;
 			}
 		} else {
 			if (addr >= 0x8ff6 && addr <= 0x8ff9) {
 				CARTRIDGE_BountyBob1(addr);
-				return 0;
 			}
 		}
 	}
@@ -1139,12 +1137,10 @@ UBYTE CARTRIDGE_BountyBob2GetByte(UWORD addr, int no_side_effects)
 		if (Atari800_machine_type == Atari800_MACHINE_5200) {
 			if (addr >= 0x5ff6 && addr <= 0x5ff9) {
 				CARTRIDGE_BountyBob2(addr);
-				return 0;
 			}
 		} else {
 			if (addr >= 0x9ff6 && addr <= 0x9ff9) {
 				CARTRIDGE_BountyBob2(addr);
-				return 0;
 			}
 		}
 	}

--- a/src/memory.c
+++ b/src/memory.c
@@ -1074,13 +1074,13 @@ UBYTE MEMORY_HwGetByte(UWORD addr, int no_side_effects)
 	case 0x8f00:
 		if (!no_side_effects)
 			CARTRIDGE_BountyBob1(addr);
-		byte = 0;
+		byte = MEMORY_dGetByte(addr);
 		break;
 	case 0x5f00:
 	case 0x9f00:
 		if (!no_side_effects)
 			CARTRIDGE_BountyBob2(addr);
-		byte = 0;
+		byte = MEMORY_dGetByte(addr);
 		break;
 	case 0xbf00:
 		if (!no_side_effects)


### PR DESCRIPTION
This is a fix for "'Bounty Bob Strikes Back' cart version doesn't recognize the space bar" #33 issue.
BBSB cart access fixes for PAGED_ATTRIB and non-PAGED_ATTRIB modes.

