### PR TITLE
Allow specification of filenames for sound and video files

### DIFF
--- a/src/atari.c
+++ b/src/atari.c
@@ -779,6 +779,7 @@ int Atari800_Initialise(int *argc, char *argv[])
 		|| !UI_Initialise(argc, argv)
 #endif
 #if (defined(SOUND) && !defined(DREAMCAST)) || defined(AVI_VIDEO_RECORDING)
+		|| !Multimedia_Initialise(argc, argv)
 		|| !File_Export_Initialise(argc, argv)
 #endif
 		/* Initialise Custom Chips */

--- a/src/atari800.man
+++ b/src/atari800.man
@@ -752,8 +752,8 @@ palette (by default the loaded palette is displayed unmodified).
 .TP
 .BI \-screenshots\  pattern
 Set filename pattern for screenshots.
-Use to override the default \fIatari000.png\fR, \fIatari001.png\fR etc.
-filenames.
+Use to override the default pattern of \fIatari###.png\fR which produces
+\fIatari000.png\fR, \fIatari001.png\fR etc. filenames.
 Hashes are replaced with raising numbers.
 Existing files are overwritten only if all the files defined by the pattern
 exist.
@@ -815,6 +815,20 @@ Set PNG image compression level 0-9 (default 6). Zero means no compression and
 larger numbers correspond to higher compression and smaller image sizes, at the
 cost of increased time to generate the compressed image. This affects both
 screenshots and the video codec.
+
+.TP
+.BI \-soundfilename\  pattern
+Set filename pattern for audio recordings.
+Use to override the default pattern of \fIatari###.wav\fR which produces
+\fIatari000.wav\fR, \fIatari001.wav\fR etc. filenames.
+Hashes are replaced with raising numbers.
+
+.TP
+.BI \-videofilename\  pattern
+Set filename pattern for video recordings.
+Use to override the default pattern of \fIatari###.avi\fR which produces
+\fIatari000.avi\fR, \fIatari001.avi\fR etc. filenames.
+Hashes are replaced with raising numbers.
 
 .SS Curses Options
 

--- a/src/multimedia.c
+++ b/src/multimedia.c
@@ -34,11 +34,11 @@
 /* sndoutput is just the file pointer for the current sound file */
 static FILE *sndoutput = NULL;
 
-#define DEFAULT_SOUND_FILENAME_FORMAT "atari%03d.wav"
+#define DEFAULT_SOUND_FILENAME_FORMAT "atari###.wav"
 
-static char sound_filename_format[FILENAME_MAX] = DEFAULT_SOUND_FILENAME_FORMAT;
+static char sound_filename_format[FILENAME_MAX];
 static int sound_no_last = -1;
-static int sound_no_max = 1000;
+static int sound_no_max = 0;
 
 #endif
 
@@ -47,11 +47,11 @@ static int sound_no_max = 1000;
 /* avioutput is just the file pointer for the current video file */
 static FILE *avioutput = NULL;
 
-#define DEFAULT_VIDEO_FILENAME_FORMAT "atari%03d.avi"
+#define DEFAULT_VIDEO_FILENAME_FORMAT "atari###.avi"
 
-static char video_filename_format[FILENAME_MAX] = DEFAULT_VIDEO_FILENAME_FORMAT;
+static char video_filename_format[FILENAME_MAX];
 static int video_no_last = -1;
-static int video_no_max = 1000;
+static int video_no_max = 0;
 
 #endif /* AVI_VIDEO_RECORDING */
 
@@ -157,6 +157,9 @@ int Multimedia_CloseFile(void)
 /* Get the next filename in the sound_file_format pattern.
    RETURNS: True if filename is available, false if no filenames left in the pattern. */
 int Multimedia_GetNextSoundFile(char *buffer, int bufsize) {
+	if (!sound_no_max) {
+		sound_no_max = Util_filenamepattern(DEFAULT_SOUND_FILENAME_FORMAT, sound_filename_format, FILENAME_MAX, NULL);
+	}
 	return Util_findnextfilename(sound_filename_format, &sound_no_last, sound_no_max, buffer, bufsize, FALSE);
 }
 
@@ -213,6 +216,9 @@ int Multimedia_WriteAudio(const unsigned char *ucBuffer, unsigned int uiSize)
 /* Get the next filename in the video_file_format pattern.
    RETURNS: True if filename is available, false if no filenames left in the pattern. */
 int Multimedia_GetNextVideoFile(char *buffer, int bufsize) {
+	if (!video_no_max) {
+		video_no_max = Util_filenamepattern(DEFAULT_VIDEO_FILENAME_FORMAT, video_filename_format, FILENAME_MAX, NULL);
+	}
 	return Util_findnextfilename(video_filename_format, &video_no_last, video_no_max, buffer, bufsize, FALSE);
 }
 

--- a/src/multimedia.h
+++ b/src/multimedia.h
@@ -3,15 +3,18 @@
 
 #include "atari.h"
 
+int Multimedia_Initialise(int *argc, char *argv[]);
 int Multimedia_IsFileOpen(void);
 int Multimedia_CloseFile(void);
 
 #ifdef SOUND
+int Multimedia_GetNextSoundFile(char *buffer, int bufsize);
 int Multimedia_OpenSoundFile(const char *szFileName);
 int Multimedia_WriteAudio(const UBYTE *ucBuffer, unsigned int uiSize);
 #endif
 
 #ifdef AVI_VIDEO_RECORDING
+int Multimedia_GetNextVideoFile(char *buffer, int bufsize);
 int Multimedia_OpenVideoFile(const char *szFileName);
 int Multimedia_WriteVideo(void);
 #endif

--- a/src/screen.c
+++ b/src/screen.c
@@ -69,14 +69,14 @@ int Screen_show_1200_leds = TRUE;
 
 #ifndef DREAMCAST
 #ifdef HAVE_LIBPNG
-#define DEFAULT_SCREENSHOT_FILENAME_FORMAT "atari%03d.png"
+#define DEFAULT_SCREENSHOT_FILENAME_FORMAT "atari###.png"
 #else
-#define DEFAULT_SCREENSHOT_FILENAME_FORMAT "atari%03d.pcx"
+#define DEFAULT_SCREENSHOT_FILENAME_FORMAT "atari###.pcx"
 #endif
 
-static char screenshot_filename_format[FILENAME_MAX] = DEFAULT_SCREENSHOT_FILENAME_FORMAT;
+static char screenshot_filename_format[FILENAME_MAX];
 static int screenshot_no_last = -1;
-static int screenshot_no_max = 1000;
+static int screenshot_no_max = 0;
 
 #endif /* !DREAMCAST */
 
@@ -474,6 +474,9 @@ int Screen_SaveScreenshot(const char *filename, int interlaced)
 void Screen_SaveNextScreenshot(int interlaced)
 {
 	char filename[FILENAME_MAX];
+	if (!screenshot_no_max) {
+		screenshot_no_max = Util_filenamepattern(DEFAULT_SCREENSHOT_FILENAME_FORMAT, screenshot_filename_format, FILENAME_MAX, NULL);
+	}
 	Util_findnextfilename(screenshot_filename_format, &screenshot_no_last, screenshot_no_max, filename, sizeof(filename), TRUE);
 	Screen_SaveScreenshot(filename, interlaced);
 }

--- a/src/screen.c
+++ b/src/screen.c
@@ -75,45 +75,9 @@ int Screen_show_1200_leds = TRUE;
 #endif
 
 static char screenshot_filename_format[FILENAME_MAX] = DEFAULT_SCREENSHOT_FILENAME_FORMAT;
+static int screenshot_no_last = -1;
 static int screenshot_no_max = 1000;
 
-/* converts "foo%bar##.pcx" to "foo%%bar%02d.pcx" */
-static void Screen_SetScreenshotFilenamePattern(const char *p)
-{
-	char *f = screenshot_filename_format;
-	char no_width = '0';
-	screenshot_no_max = 1;
-	/* 9 because sprintf'ed "no" can be 9 digits */
-	while (f < screenshot_filename_format + FILENAME_MAX - 9) {
-		/* replace a sequence of hashes with e.g. "%05d" */
-		if (*p == '#') {
-			if (no_width > '0') /* already seen a sequence of hashes */
-				break;          /* invalid */
-			/* count hashes */
-			do {
-				screenshot_no_max *= 10;
-				p++;
-				no_width++;
-				/* now no_width is the number of hashes seen so far
-				   and p points after the counted hashes */
-			} while (no_width < '9' && *p == '#'); /* no more than 9 hashes */
-			*f++ = '%';
-			*f++ = '0';
-			*f++ = no_width;
-			*f++ = 'd';
-			continue;
-		}
-		if (*p == '%')
-			*f++ = '%'; /* double the percents */
-		*f++ = *p;
-		if (*p == '\0')
-			return; /* ok */
-		p++;
-	}
-	Log_print("Invalid filename pattern for screenshots, using default.");
-	strcpy(screenshot_filename_format, DEFAULT_SCREENSHOT_FILENAME_FORMAT);
-	screenshot_no_max = 1000;
-}
 #endif /* !DREAMCAST */
 
 int Screen_Initialise(int *argc, char *argv[])
@@ -129,7 +93,7 @@ int Screen_Initialise(int *argc, char *argv[])
 #ifndef DREAMCAST
 		if (strcmp(argv[i], "-screenshots") == 0) {
 			if (i_a)
-				Screen_SetScreenshotFilenamePattern(argv[++i]);
+				screenshot_no_max = Util_filenamepattern(argv[++i], screenshot_filename_format, FILENAME_MAX, DEFAULT_SCREENSHOT_FILENAME_FORMAT);
 			else a_m = TRUE;
 		}
 		else
@@ -455,24 +419,6 @@ void Screen_Draw1200LED(void)
 }
 
 #ifndef DREAMCAST
-void Screen_FindScreenshotFilename(char *buffer, unsigned bufsize)
-{
-	static int no = -1;
-	static int overwrite = FALSE;
-
-	for (;;) {
-		if (++no >= screenshot_no_max) {
-			no = 0;
-			overwrite = TRUE;
-		}
-		snprintf(buffer, bufsize, screenshot_filename_format, no);
-		if (overwrite)
-			break;
-		if (!Util_fileexists(buffer))
-			break; /* file does not exist - we can create it */
-	}
-}
-
 static int striendswith(const char *s1, const char *s2)
 {
 	int pos;
@@ -528,7 +474,7 @@ int Screen_SaveScreenshot(const char *filename, int interlaced)
 void Screen_SaveNextScreenshot(int interlaced)
 {
 	char filename[FILENAME_MAX];
-	Screen_FindScreenshotFilename(filename, sizeof(filename));
+	Util_findnextfilename(screenshot_filename_format, &screenshot_no_last, screenshot_no_max, filename, sizeof(filename), TRUE);
 	Screen_SaveScreenshot(filename, interlaced);
 }
 #endif /* !DREAMCAST */

--- a/src/ui.c
+++ b/src/ui.c
@@ -1279,19 +1279,15 @@ static void SoundRecording(void)
 		return;
 	}
 	if (!Multimedia_IsFileOpen()) {
-		int no = 0;
-		do {
-			char buffer[32];
-			snprintf(buffer, sizeof(buffer), "atari%03d.wav", no);
-			if (!Util_fileexists(buffer)) {
-				/* file does not exist - we can create it */
-				FilenameMessage(Multimedia_OpenSoundFile(buffer)
-					? "Recording sound to file \"%s\""
-					: "Can't write to file \"%s\"", buffer);
-				return;
-			}
-		} while (++no < 1000);
-		UI_driver->fMessage("All atariXXX.wav files exist!", 1);
+		char buffer[FILENAME_MAX];
+		if (Multimedia_GetNextSoundFile(buffer, sizeof(buffer))) {
+			/* file does not exist - we can create it */
+			FilenameMessage(Multimedia_OpenSoundFile(buffer)
+				? "Recording sound to file \"%s\""
+				: "Can't write to file \"%s\"", buffer);
+			return;
+		}
+		UI_driver->fMessage("All sound files exist!", 1);
 	}
 	else {
 		Multimedia_CloseFile();
@@ -1304,19 +1300,15 @@ static void SoundRecording(void)
 static void VideoRecording(void)
 {
 	if (!Multimedia_IsFileOpen()) {
-		int no = 0;
-		do {
-			char buffer[32];
-			snprintf(buffer, sizeof(buffer), "atari%03d.avi", no);
-			if (!Util_fileexists(buffer)) {
-				/* file does not exist - we can create it */
-				FilenameMessage(Multimedia_OpenVideoFile(buffer)
-					? "Recording video to file \"%s\""
-					: "Can't write to file \"%s\"", buffer);
-				return;
-			}
-		} while (++no < 1000);
-		UI_driver->fMessage("All atariXXX.avi files exist!", 1);
+		char buffer[FILENAME_MAX];
+		if (Multimedia_GetNextVideoFile(buffer, sizeof(buffer))) {
+			/* file does not exist - we can create it */
+			FilenameMessage(Multimedia_OpenVideoFile(buffer)
+				? "Recording video to file \"%s\""
+				: "Can't write to file \"%s\"", buffer);
+			return;
+		}
+		UI_driver->fMessage("All video files exist!", 1);
 	}
 	else {
 		Multimedia_CloseFile();

--- a/src/util.c
+++ b/src/util.c
@@ -359,7 +359,7 @@ void Util_catpath(char *result, const char *path1, const char *path2)
 			? "%s%s" : "%s" Util_DIR_SEP_STR "%s", path1, path2);
 }
 
-int Util_filenamepattern(const char *p, char *buffer, int bufsize, const char *default_pattern)
+static int parse_hashes(const char *p, char *buffer, int bufsize)
 {
 	char *f = buffer;
 	char no_width = '0';
@@ -391,9 +391,18 @@ int Util_filenamepattern(const char *p, char *buffer, int bufsize, const char *d
 			return no_max; /* ok */
 		p++;
 	}
-	Log_print("Invalid filename pattern, using default.");
-	strcpy(buffer, default_pattern);
-	no_max = 1000;
+	return 0;
+}
+
+int Util_filenamepattern(const char *p, char *buffer, int bufsize, const char *default_pattern)
+{
+	int no_max;
+
+	no_max = parse_hashes(p, buffer, bufsize);
+	if (!no_max && default_pattern) {
+		Log_print("Invalid filename pattern, using default.");
+		no_max = parse_hashes(default_pattern, buffer, bufsize);
+	}
 	return no_max;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -60,6 +60,7 @@
 #include "atari.h"
 #include "platform.h"
 #include "util.h"
+#include "log.h"
 
 int Util_chrieq(char c1, char c2)
 {
@@ -356,6 +357,65 @@ void Util_catpath(char *result, const char *path1, const char *path2)
 		 || path2[0] == '/' || path1[strlen(path1) - 1] == '/'
 #endif
 			? "%s%s" : "%s" Util_DIR_SEP_STR "%s", path1, path2);
+}
+
+int Util_filenamepattern(const char *p, char *buffer, int bufsize, const char *default_pattern)
+{
+	char *f = buffer;
+	char no_width = '0';
+	int no_max = 1;
+	/* 9 because sprintf'ed "no" can be 9 digits */
+	while (f < buffer + bufsize - 9) {
+		/* replace a sequence of hashes with e.g. "%05d" */
+		if (*p == '#') {
+			if (no_width > '0') /* already seen a sequence of hashes */
+				break;          /* invalid */
+			/* count hashes */
+			do {
+				no_max *= 10;
+				p++;
+				no_width++;
+				/* now no_width is the number of hashes seen so far
+				   and p points after the counted hashes */
+			} while (no_width < '9' && *p == '#'); /* no more than 9 hashes */
+			*f++ = '%';
+			*f++ = '0';
+			*f++ = no_width;
+			*f++ = 'd';
+			continue;
+		}
+		if (*p == '%')
+			*f++ = '%'; /* double the percents */
+		*f++ = *p;
+		if (*p == '\0')
+			return no_max; /* ok */
+		p++;
+	}
+	Log_print("Invalid filename pattern, using default.");
+	strcpy(buffer, default_pattern);
+	no_max = 1000;
+	return no_max;
+}
+
+int Util_findnextfilename(const char *format, int *no_last, int no_max, char *buffer, int bufsize, int allow_overwrite)
+{
+	int no;
+
+	/* negative number to initialize */
+	if (*no_last < 0) *no_last = -1;
+	no = *no_last;
+	for (;;) {
+		if ((++no >= no_max) & !allow_overwrite) {
+			return FALSE;
+		}
+		snprintf(buffer, bufsize, format, no % no_max);
+		*no_last = no;
+		if ((no >= no_max) && allow_overwrite)
+			break;
+		if (!Util_fileexists(buffer))
+			break; /* file does not exist - we can create it */
+	}
+	return TRUE;
 }
 
 int Util_fileexists(const char *filename)

--- a/src/util.h
+++ b/src/util.h
@@ -138,6 +138,7 @@ void Util_catpath(char *result, const char *path1, const char *path2);
 /* Takes input string p in the form of "foo%bar##.ext" and converts to "foo%%bar%02d.ext",
    storing the result in the char array pointed to by buffer (with a max size bufsize).
    At most 9 digits are supported; if more that that, uses the format specifed in default.
+   Default format should use the hash specification also, like "atari###.ext".
 
    Returns the maximum number supported by the pattern. */
 int Util_filenamepattern(const char *p, char *buffer, int bufsize, const char *default_pattern);

--- a/src/util.h
+++ b/src/util.h
@@ -135,6 +135,23 @@ void Util_splitpath(const char *path, char *dir_part, char *file_part);
    or ends with the separator char, or path2 starts with the separator char. */
 void Util_catpath(char *result, const char *path1, const char *path2);
 
+/* Takes input string p in the form of "foo%bar##.ext" and converts to "foo%%bar%02d.ext",
+   storing the result in the char array pointed to by buffer (with a max size bufsize).
+   At most 9 digits are supported; if more that that, uses the format specifed in default.
+
+   Returns the maximum number supported by the pattern. */
+int Util_filenamepattern(const char *p, char *buffer, int bufsize, const char *default_pattern);
+
+/* Find the next available filename given by format (which can be found using a call to
+   Util_filenamepattern). The maximum value must be given in no_max, and the returned
+   filename is stored in buffer, with max bufsize characters. The no_last pointer is
+   used to remember the last successful value. no_last should be initialized with a -1
+   before calling this function for the first time.
+
+   Returns TRUE if successful, or FALSE if allow_overwrite is FALSE and could not find
+   an unused filename. Will always be successful if allow_overwrite is TRUE. */
+int Util_findnextfilename(const char *format, int *no_last, int no_max, char *buffer, int bufsize, int allow_overwrite);
+
 
 /* File I/O -------------------------------------------------------------- */
 


### PR DESCRIPTION
Added command line options -soundfilename and -videofilename to specify filename pattern like screenshot filename pattern. Moved the filename pattern code into util.c and modified the functions to make them work with the general case, not just screenshots. Changed the default filename patterns to use the hash notation so max value doesn't get out of sync of default pattern ever changes in the code.