### PR TITLE
Video codec improvements & libatari800 fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,7 @@ dnl BeOS has a real issue with redundant-decls
         ;;
     libatari800)
         AC_DEFINE(LIBATARI800,1,[Target: Atari800 as a library.])
+        AC_DEFINE(SUPPORTS_PLATFORM_CONFIGURE,1,[Additional config file options.])
         ;;
     x11*)
         AC_DEFINE(X11,1,[Target: Standard X11.])

--- a/src/atari800.man
+++ b/src/atari800.man
@@ -810,6 +810,12 @@ available if PNG support was compiled into the emulator.
 .PD
 .RE
 .TP
+.BI \-keyframe-interval\  ms
+Set the time between keyframes in milliseconds (default 1000 ms).
+Some video codecs use keyframes and inter-frames, which encode full frames and
+differences between frames, respectively. Inter-frames are typically much smaller
+than full frames, but most video players can only seek to keyframes.
+.TP
 .BI \-pnglevel\  num
 Set PNG image compression level 0-9 (default 6). Zero means no compression and
 larger numbers correspond to higher compression and smaller image sizes, at the
@@ -1588,133 +1594,110 @@ joysticks are also supported.
 .PD 1
 .SH VIDEO RECORDING
 .B atari800
-is capable of recording the emulation session to AVI format multimedia files.
-Video frames are stored using either a high compression codec (the
-\fB\-videocodec png\fR option) or a low compression codec (the \fB\-videocodec
-rle\fR option). Audio is stored as raw PCM data using the sample size specified
-by the \fB\-audio16\fR or \fB\-audio8\fR options. To record without sound,
-specify the \fB\-nosound\fR option.
+is capable of recording the emulation session to AVI format multimedia files. A
+choice of video codecs is available, while audio is stored as raw PCM data using
+the sample size specified by the \fB\-audio16\fR or \fB\-audio8\fR options. To
+record without sound, specify the \fB\-nosound\fR option.
 .PP
-The high compression codec is based on PNG images, support for which is a
-compile-time option when building the emulator. It is the default codec if
-available, as it is supported by virtually all modern players (including vlc,
-ffmpeg and GStreamer-based players). Windows Media Player does not support this
-codec, however.
+The default codec and the one best suited for most recording is based on
+run-length encoding (RLE), and produces its high compression due to its use of
+inter-frames to encode only changes from the previous frame. It can be specified
+by the \fB\-videocodec rle\fR option. It is supported by players like VLC and
+ffmpeg-based players, as well as legacy players like Windows Media Player. It is
+not supported by GStreamer-based players.
 .PP
-The low compression codec is always available. It is based on run-length
-encoding, which is much less efficient than the PNG codec. Some modern players
-support this, but the only practical use should be if PNG support is not
-available or legacy Windows Media Player support is required.
+An alternate codec based on PNG images is a compile-time option when building
+the emulator, and if available can be specified by the \fB\-videocodec png\fR
+option. Testing shows that its strength is scrolling games with complex
+backgrounds. Because it does not have inter-frames, its compression suffers in
+comparison to RLE when the emulation produces more static backgrounds. Videos
+produced by this codec are supported by ffmpeg and GStreamer-based players, but
+not VLC or Windows Media Player.
 .PP
 The AVI files produced by \fBatari800\fR can be imported into YouTube regardless
 of the selected codec.
 .PP
-Currently there is a limit of 4GB for video size.
+Currently there is a limit of 4GB for video size. The maximum recording time for
+this size limit depends on many factors. Some examples can be seen in the tables
+below:
 .PP
-The maximum recording time for this 4GB size varies, mostly depending on the
-compression ability of the video codec. The audio is not compressed, so every
-second of audio consumes 88200 bytes at the default rate of 44.1kHz with 16-bit
-samples, or 44100 bytes when using 8-bit samples.
-.PP
-The compressed size of video frames can vary during recording as the emulated
-screen changes. Games that have plain backgrounds like Miner 2049er and Jumpman
-compress better than those that have complex playfields like Alley Cat or
-Boulder Dash. Sample recording times (in hours) for these games are shown below,
-using the size of a typical video frame as the average for the entire video and
-calculating the amount of recording time available for a 4GB file.
-
-.PP
-NTSC, RLE codec:
-
+RLE codec:
 .TS
 tab(@), center, box;
-l | c | c s s
-c | c | _ _ _
-c | c | c c c
-l | c | c c c
-l | cB | cB cB cB.
-@Typical@Recording time (hours:minutes)
+l | c | c s s | c s s
+c | c | _ _ _ | _ _ _
+c | c | c c c | c c c
+l | c | c c c | c c c
+l | cB | cB cB cB | cB cB cB.
+@Average@NTSC recording time@PAL recording time
 Game@video@
-@frame@no@8-bit@16-bit
-@size@audio@audio@audio
+@frame@no@8-bit@16-bit@no@8-bit@16-bit
+@size@audio@audio@audio@audio@audio@audio
 _
-Miner 2049er@5.2k@3:42@3:15@2:54@
-Jumpman@8.7k@2:13@2:03@1:54@
-Alley Cat@18k@1:04@1:02@0:59@
-Boulder Dash@34k@0:34@0:33@0:32@
+
+Miner 2049er@0.5k@37 hr@15 hr@9h 45m@44 hr@16 hr@10 hr@
+Jumpman@0.4k@45 hr@16 hr@10 hr@55 hr@17 hr@10 hr@
+Alley Cat@0.8k@23 hr@12 hr@8h 30m@28 hr@13 hr@9h 00m@
+Dropzone@1.8k@10 hr@7h 30m@5h 50m@12 hr@8h 35m@6h 30m@
+AtariBlast!@5.7k@3h 20m@3h 00m@2h 40m@4h 00m@3h 30m@3h 05m@
+Boulder Dash@9.1k@2h 05m@1h 55m@1h 50m@2h 30m@2h 15m@2h 05m@
 .TE
 
 .PP
-NTSC, PNG codec (default compression level):
+PNG codec (default compression level):
 .TS
 tab(@), center, box;
-l | c | c s s
-c | c | _ _ _
-c | c | c c c
-l | c | c c c
-l | cB | cB cB cB.
-@Typical@Recording time (hours:minutes)
+l | c | c s s | c s s
+c | c | _ _ _ | _ _ _
+c | c | c c c | c c c
+l | c | c c c | c c c
+l | cB | cB cB cB | cB cB cB.
+@Average@NTSC recording time@PAL recording time
 Game@video@
-@frame@no@8-bit@16-bit
-@size@audio@audio@audio
+@frame@no@8-bit@16-bit@no@8-bit@16-bit
+@size@audio@audio@audio@audio@audio@audio
 _
-Miner 2049er@2.2k@8:43@6:32@5:16@
-Jumpman@2.4k@8:00@6:08@5:00@
-Alley Cat@4.1k@4:42@3:59@3:28@
-Boulder Dash@4.5k@4:17@3:41@3:14@
+
+Miner 2049er@2.2k@8h 40m@6h 30m@5h 15m@10 hr@7h 25m@5h 50m@
+Jumpman@2.4k@8h 00m@6h 05m@5h 00m@9h 35m@7h 00m@5h 35m@
+Alley Cat@4.1k@4h 40m@3h 55m@3h 25m@5h 35m@4h 35m@3h 55m@
+Dropzone@2.8k@6h 50m@5h 25m@4h 30m@8h 15m@6h 15m@5h 05m@
+AtariBlast!@4.2k@4h 35m@3h 50m@3h 20m@5h 30m@4h 30m@3h 50m@
+Boulder Dash@4.5k@4h 15m@3h 40m@3h 10m@5h 05m@4h 15m@3h 40m@
 .TE
 
 .PP
-NTSC, PNG codec (compression level 9):
+PNG codec (compression level 9):
 .TS
 tab(@), center, box;
-l | c | c s s
-c | c | _ _ _
-c | c | c c c
-l | c | c c c
-l | cB | cB cB cB.
-@Typical@Recording time (hours:minutes)
+l | c | c s s | c s s
+c | c | _ _ _ | _ _ _
+c | c | c c c | c c c
+l | c | c c c | c c c
+l | cB | cB cB cB | cB cB cB.
+@Average@NTSC recording time@PAL recording time
 Game@video@
-@frame@no@8-bit@16-bit
-@size@audio@audio@audio
+@frame@no@8-bit@16-bit@no@8-bit@16-bit
+@size@audio@audio@audio@audio@audio@audio
 _
-Miner 2049er@2.0k@9:35@7:01@5:34@
-Jumpman@2.1k@9:08@6:46@5:25@
-Alley Cat@3.8k@5:04@4:15@3:40@
-Boulder Dash@2.5k@7:41@5:56@4:52@
+
+Miner 2049er@2.0k@9h 35m@7h 00m@5h 30m@11 hr@8h 00m@6h 10m@
+Jumpman@2.1k@9h 05m@6h 45m@5h 25m@10 hr@7h 40m@6h 00m@
+Alley Cat@3.8k@5h 00m@4h 15m@3h 40m@6h 05m@4h 55m@4h 10m@
+Dropzone@2.7k@7h 05m@5h 35m@4h 35m@8h 30m@6h 25m@5h 10m@
+AtariBlast!@3.8k@5h 00m@4h 15m@3h 40m@6h 05m@4h 55m@4h 10m@
+Boulder Dash@2.5k@7h 40m@5h 55m@4h 50m@9h 10m@6h 50m@5h 25m@
 .TE
 
 .PP
-Unless legacy playback is needed, it is recommended to use the PNG video codec.
-.PP
-Audio sizes make quite a large difference at high video compression levels
-because the size of the audio samples approaches the size of the video. Using
-8-bit audio is one simple way to increase recording time if 16-bit POKEY audio
-is not used during emulation.
+Audio is uncompressed and takes about 1.4k per frame for NTSC (about 1.8k per
+frame for PAL), and is larger than the average video frame size in many cases.
+Using 8-bit audio is one simple way to increase recording time if 16-bit POKEY
+audio is not used during emulation.
 .PP
 Longer recording times are available when emulating at the PAL frame rate
 because there are 10 fewer video frames per second as compared to NTSC, while
 the audio sampling rate is the same as NTSC.
-
-.PP
-PAL, PNG codec (compression level 9):
-.TS
-tab(@), center, box;
-l | c | c s s
-c | c | _ _ _
-c | c | c c c
-l | c | c c c
-l | cB | cB cB cB.
-@Typical@Recording time (hours:minutes)
-Game@video@
-@frame@no@8-bit@16-bit
-@size@audio@audio@audio
-_
-Miner 2049er@2.0k@11:30@8:00@6:10@
-Jumpman@2.1k@10:58@7:44@6:01@
-Alley Cat@3.8k@6:05@4:56@4:10@
-Boulder Dash@2.5k@9:13@6:50@5:27@
-.TE
 
 .PD 1
 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -62,6 +62,9 @@
 #ifdef SOUND
 #include "sound.h"
 #endif
+#if (defined(SOUND) && !defined(DREAMCAST)) || defined(AVI_VIDEO_RECORDING)
+#include "file_export.h"
+#endif
 
 int CFG_save_on_exit = FALSE;
 
@@ -335,6 +338,10 @@ int CFG_LoadConfig(const char *alternate_config_filename)
 			else if (Sound_ReadConfig(string, ptr)) {
 			}
 #endif /* defined(SOUND) && defined(SOUND_THIN_API) */
+#if (defined(SOUND) && !defined(DREAMCAST)) || defined(AVI_VIDEO_RECORDING)
+			else if (File_Export_ReadConfig(string, ptr)) {
+			}
+#endif
 			else {
 #ifdef SUPPORTS_PLATFORM_CONFIGURE
 				if (!PLATFORM_Configure(string, ptr)) {
@@ -476,6 +483,9 @@ int CFG_WriteConfig(void)
 #if defined(SOUND) && defined(SOUND_THIN_API)
 	Sound_WriteConfig(fp);
 #endif /* defined(SOUND) && defined(SOUND_THIN_API) */
+#if (defined(SOUND) && !defined(DREAMCAST)) || defined(AVI_VIDEO_RECORDING)
+	File_Export_WriteConfig(fp);
+#endif
 #ifdef SUPPORTS_PLATFORM_CONFIGSAVE
 	PLATFORM_ConfigSave(fp);
 #endif

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -846,7 +846,8 @@ void CPU_GO(int limit)
 	OPCODE(00)				/* BRK */
 #ifdef LIBATARI800
 #ifdef HAVE_SETJMP
-		longjmp(libatari800_cpu_crash, LIBATARI800_BRK_INSTRUCTION);
+		if (!libatari800_continue_on_brk)
+			longjmp(libatari800_cpu_crash, LIBATARI800_BRK_INSTRUCTION);
 #endif /* HAVE_SETJMP */
 #else /* LIBATARI800 */
 #ifdef MONITOR_BREAK

--- a/src/file_export.c
+++ b/src/file_export.c
@@ -110,7 +110,20 @@ static ULONG *frame_indexes;
 static int num_frames_allocated;
 static int rle_buffer_size = 0;
 static UBYTE *rle_buffer = NULL;
+static int reference_screen_size = 0;
+static UBYTE *reference_screen = NULL;
+
+/* current_screen_size is used as a flag before the frame is generated. -1 means
+   awaiting frame generation, -2 means error, and 0 or greater means the video
+   frame has been encoded. Note that some encoders can create inter-frames with
+   zero length */
 static int current_screen_size = -1;
+
+/* Some codecs allow for keyframes (full frame compression) and inter-frames
+   (only the differences from the previous frame) */
+static int keyframe_interval = 1000;
+static float keyframe_residual;
+static int current_is_keyframe = 0;
 
 #ifdef SOUND
 static ULONG samples_written;
@@ -163,6 +176,16 @@ int File_Export_Initialise(int *argc, char *argv[])
 			}
 			else a_m = TRUE;
 		}
+		else if (strcmp(argv[i], "-keyframe-interval") == 0) {
+			if (i_a) {
+				keyframe_interval = Util_sscandec(argv[++i]);
+				if (keyframe_interval < 1) {
+					Log_print("Invalid keyframe interval time, must be 1 millisecond or greater.");
+					return FALSE;
+				}
+			}
+			else a_m = TRUE;
+		}
 #endif
 #ifdef HAVE_LIBPNG
 		else if (strcmp(argv[i], "-pnglevel") == 0) {
@@ -185,6 +208,8 @@ int File_Export_Initialise(int *argc, char *argv[])
 #endif
 				);
 				Log_print("\t                 Select video codec, (default: auto)");
+				Log_print("\t-keyframe-interval <ms>");
+				Log_print("\t                 Select interval between video keyframes in milliseconds");
 #endif
 #ifdef HAVE_LIBPNG
 				Log_print("\t-pnglevel <n>    Set PNG image compression level 0-9 (default 6)");
@@ -208,7 +233,9 @@ int File_Export_Initialise(int *argc, char *argv[])
 
 int File_Export_ReadConfig(char *string, char *ptr)
 {
-	if (strcmp(string, "VIDEO_CODEC") == 0) {
+	if (0) {}
+#ifdef AVI_VIDEO_RECORDING
+	else if (strcmp(string, "VIDEO_CODEC") == 0) {
 		if (Util_stricmp(ptr, "rle") == 0)
 			requested_video_codec = effective_video_codec = VIDEO_CODEC_MRLE;
 #ifdef HAVE_LIBPNG
@@ -221,6 +248,13 @@ int File_Export_ReadConfig(char *string, char *ptr)
 		}
 		else return FALSE;
 	}
+	else if (strcmp(string, "VIDEO_CODEC_KEYFRAME_INTERVAL") == 0) {
+		int num = Util_sscandec(ptr);
+		if (num > 0)
+			keyframe_interval = num;
+		else return FALSE;
+	}
+#endif
 #ifdef HAVE_LIBPNG
 	else if (strcmp(string, "PNG_COMPRESSION_LEVEL") == 0) {
 		int num = Util_sscandec(ptr);
@@ -235,6 +269,7 @@ int File_Export_ReadConfig(char *string, char *ptr)
 
 void File_Export_WriteConfig(FILE *fp)
 {
+#ifdef AVI_VIDEO_RECORDING
 	switch (requested_video_codec) {
 		case VIDEO_CODEC_AUTO:
 			fprintf(fp, "VIDEO_CODEC=AUTO\n");
@@ -248,6 +283,8 @@ void File_Export_WriteConfig(FILE *fp)
 			break;
 #endif
 	}
+	fprintf(fp, "VIDEO_CODEC_KEYFRAME_INTERVAL=%d\n", keyframe_interval);
+#endif
 #ifdef HAVE_LIBPNG
 	fprintf(fp, "PNG_COMPRESSION_LEVEL=%d\n", png_compression_level);
 #endif
@@ -448,7 +485,7 @@ static void PNG_SaveToBuffer(png_structp png_ptr, png_bytep data, png_size_t len
 		}
 		else {
 			Log_print("AVI write error: video compression buffer size too small.");
-			current_screen_size = -1;
+			current_screen_size = -2;
 		}
 	}
 }
@@ -486,6 +523,7 @@ void PNG_SaveScreen(FILE *fp, UBYTE *ptr1, UBYTE *ptr2)
 	}
 #ifdef AVI_VIDEO_RECORDING
 	if (fp == NULL) {
+		current_screen_size = 0;
 		png_set_write_fn(png_ptr, NULL, PNG_SaveToBuffer, NULL);
 	}
 	else
@@ -918,7 +956,9 @@ FILE *AVI_OpenFile(const char *szFileName)
 	size_riff = 0;
 	size_movi = 0;
 	frames_written = 0;
-	current_screen_size = 0;
+	keyframe_residual = 0.0;
+	current_is_keyframe = 1; /* first frame always a keyframe */
+	current_screen_size = -1; /* screen not generated yet */
 
 	fps = Atari800_tv_mode == Atari800_TV_PAL ? Atari800_FPS_PAL : Atari800_FPS_NTSC;
 	set_video_margins();
@@ -927,11 +967,27 @@ FILE *AVI_OpenFile(const char *szFileName)
 	frame_indexes = (ULONG *)Util_malloc(num_frames_allocated * sizeof(ULONG));
 	memset(frame_indexes, 0, num_frames_allocated * sizeof(ULONG));
 
-	rle_buffer_size = Screen_WIDTH * Screen_HEIGHT;
+	/* worst case for RLE compression is where no pixel has the same color as
+	   its neighbor, resulting in 256 bytes per 254 pixels, plus the end of line
+	   marker for each line plus the end of bitmap marker. */
+	rle_buffer_size = ((((int)(ceil(video_width / 254)) * 2) + video_width + 2) * video_height) + 2;
 	rle_buffer = (UBYTE *)Util_malloc(rle_buffer_size);
 
+	switch (effective_video_codec) {
+#ifdef HAVE_LIBPNG
+		case VIDEO_CODEC_PNG:
+			reference_screen_size = 0;
+			reference_screen = NULL;
+			break;
+#endif
+		default:
+			reference_screen_size = Screen_WIDTH * Screen_HEIGHT;
+			reference_screen = (UBYTE *)Util_malloc(reference_screen_size);
+			break;
+	}
+
 #ifdef SOUND
-	current_audio_samples = 0;
+	current_audio_samples = -1;
 	samples_written = 0;
 
 	if (Sound_enabled) {
@@ -1013,6 +1069,9 @@ static int AVI_WriteFrame(FILE *fp) {
 		+ 0x10000 * audio_size
 #endif
 		;
+	if (current_is_keyframe) {
+		frame_indexes[frames_written] |= 0x80000000;
+	}
 	frames_written++;
 	if (frames_written >= num_frames_allocated) {
 		num_frames_allocated += FRAME_INDEX_ALLOC_SIZE;
@@ -1035,10 +1094,31 @@ static int AVI_WriteFrame(FILE *fp) {
 		largest_video_frame = current_screen_size;
 	}
 
+	/* A keyframe is requested when the interval has passed, unless Motion-PNG
+	   is used. Motion-PNG doesn't have the concept of deltas from the previous
+	   frame; instead, everything is a keyframe. */
+	switch (effective_video_codec) {
+#ifdef HAVE_LIBPNG
+		case VIDEO_CODEC_PNG:
+			current_is_keyframe = TRUE;
+			break;
+#endif
+		default:
+			keyframe_residual += 1000.0 / fps;
+			if (keyframe_residual > keyframe_interval) {
+				current_is_keyframe = TRUE;
+				keyframe_residual = keyframe_residual - ((int)(keyframe_residual / keyframe_interval) * keyframe_interval);
+			}
+			else {
+				current_is_keyframe = FALSE;
+			}
+			break;
+	}
+
 	/* reset size indicators for next frame */
-	current_screen_size = 0;
+	current_screen_size = -1;
 #ifdef SOUND
-	current_audio_samples = 0;
+	current_audio_samples = -1;
 #endif
 
 	if (size_limit > MAX_RECORDING_SIZE) {
@@ -1055,35 +1135,86 @@ static int AVI_WriteFrame(FILE *fp) {
    mpv), as well as proprietary applications like Windows Media Player. See
    https://wiki.multimedia.cx/index.php?title=Microsoft_RLE for a description of
    the format. */
-static int MRLE_CompressLine(UBYTE *buf, const UBYTE *ptr, int width) {
-	int x;
-	int size;
-	UBYTE last;
-	UBYTE count;
 
-	x = 0;
-	size = 0;
+static int MRLE_CompressLine(UBYTE *buf, const UBYTE *ptr, int width) {
+	int extra;
+	int count;
+	UBYTE last;
+	UBYTE *buf_start;
+	const UBYTE *run_start;
+	const UBYTE *ptr_end;
+
+	buf_start = buf;
+	ptr_end = ptr + width;
 	do {
 		last = *ptr;
-		count = 0;
+		run_start = ptr;
 		do {
 			ptr++;
-			count++;
-			x++;
-		} while (last == *ptr && x < width && count < 255);
-		*buf++ = count;
-		*buf++ = last;
-		size += 2;
-	} while (x < width);
-	return size;
+		} while (last == *ptr && ptr < ptr_end);
+		count = ptr - run_start;
+		if (count > 1) {
+			/* Run of same color pixels */
+			while (count > 0) {
+				if (count > 254) {
+					*buf++ = 254;
+					count -= 254;
+				}
+				else {
+					*buf++ = count;
+					count = 0;
+				}
+				*buf++ = last;
+			}
+			/* try to match another run of a color */
+			continue;
+		}
+		else {
+			/* run of different pixels, stopping at next pair of matching pixels */
+			while (ptr < ptr_end - 1 && *ptr != *(ptr+1) && *(ptr+1) != *(ptr+2)) {
+				ptr++;
+			}
+			while (run_start < ptr) {
+				count = ptr - run_start;
+				if (count > 254) {
+					/* stop at 254 to avoid use of padding byte for this chunk */
+					count = 254;
+				}
+
+				if (count < 3) {
+					/* can't do a data copy length of 1 or 2 directly */
+					*buf++ = 1;
+					*buf++ = *run_start++;
+					if (count == 2) {
+						*buf++ = 1;
+						*buf++ = *run_start++;
+					}
+				}
+				else {
+					/* data copy of length 3 to 255 can be done in one encoding */
+					*buf++ = 0;
+					*buf++ = count;
+					extra = count & 1;
+					while (count-- > 0) {
+						*buf++ = *run_start++;
+					}
+					if (extra) *buf++ = 0;
+				}
+			}
+		}
+	} while (ptr < ptr_end);
+
+	/* mark end of line */
+	*buf++ = 0;
+	*buf++ = 0;
+	return buf - buf_start;
 }
 
-/* MRLE_CreateFrame fills the output buffer with the fourcc type 'mrle' run
+/* MRLE_CreateKeyframe fills the output buffer with the fourcc type 'mrle' run
    length encoding data using the paletted data of the Atari screen.
 
-   RETURNS: number of encoded bytes, or -1 if buffer not large enough to hold
-   encoded data */
-int MRLE_CreateFrame(UBYTE *buf, int bufsize, const UBYTE *source) {
+   RETURNS: number of encoded bytes */
+static int MRLE_CreateKeyframe(UBYTE *buf, int bufsize, const UBYTE *source) {
 	UBYTE *buf_start;
 	const UBYTE *ptr;
 	int y;
@@ -1097,22 +1228,8 @@ int MRLE_CreateFrame(UBYTE *buf, int bufsize, const UBYTE *source) {
 	for (y = (video_top_margin + video_height)-1; y >= video_top_margin; y--) {
 		ptr = source + (y * Screen_WIDTH) + video_left_margin;
 
-		/* worst case for RLE compression is where no pixel has the same color
-		   as its neighbor,  resulting in twice the number of bytes as pixels.
-		   Each line needs the end of line marker, plus possibly the end of
-		   bitmap marker. If buffer size remaining is less than this, it's too
-		   small. */
-		if (bufsize < (video_width * 2 + 2 + 2)) {
-			Log_print("AVI write error: video compression buffer size too small.");
-			return -1;
-		}
 		size = MRLE_CompressLine(buf, ptr, video_width);
 		buf += size;
-		bufsize -= size + 2;
-
-		/* mark end of line */
-		*buf++ = 0;
-		*buf++ = 0;
 	}
 
 	/* mark end of bitmap */
@@ -1122,13 +1239,190 @@ int MRLE_CreateFrame(UBYTE *buf, int bufsize, const UBYTE *source) {
 	return buf - buf_start;
 }
 
+static int MRLE_CompressDelta(UBYTE *buf, const UBYTE *ptr, UBYTE *ref, int width, int *dy) {
+	int extra;
+	int count;
+	UBYTE last;
+	UBYTE *buf_start;
+	const UBYTE *run_start;
+	const UBYTE *ptr_end;
+	UBYTE *ref_end;
+
+	buf_start = buf;
+	ptr_end = ptr + width;
+	ref_end = ref + width;
+
+	/* right margin won't change, so find it outside the main loop */
+	while (*(ptr_end - 1) == *(ref_end - 1) && ptr < ptr_end) {
+		ptr_end--;
+		ref_end--;
+	}
+
+	while (ptr < ptr_end) {
+		run_start = ptr;
+
+		/* check for next change from reference screen */
+		while (*ptr == *ref && ptr < ptr_end) {
+			ptr++;
+			ref++;
+		}
+		if (ptr == ptr_end) break; /* no more differences in rest of scan line! */
+
+		/* skipping pixels that are the same as the reference image */
+		count = ptr - run_start;
+
+		/* it takes 4 bytes to encode a skip, so it's possible that the skip
+		   takes more space than just encoding. Force the skip if the pixel
+		   count is big enough, otherwise reset the pointer and just encode as
+		   normal. */
+		if (count > 4 || *dy) {
+			do {
+				*buf++ = 0;
+				*buf++ = 2;
+				*buf++ = (UBYTE)(count > 255 ? 255 : count);
+				*buf++ = (UBYTE)*dy;
+
+				count -= 255;
+				*dy = 0; /* dy will never be more than 255 because there are only 240 lines in Screen_atari! */
+			} while (count > 0);
+		}
+		else {
+			ptr -= count;
+			ref -= count;
+		}
+
+		/* encode the differences */
+		last = *ptr;
+		run_start = ptr;
+		do {
+			ptr++;
+			ref++;
+		} while (last == *ptr && ptr < ptr_end);
+		count = ptr - run_start;
+		if (count > 1) {
+			/* Run of same color pixels */
+			while (count > 0) {
+				if (count > 254) {
+					*buf++ = 254;
+					count -= 254;
+				}
+				else {
+					*buf++ = count;
+					count = 0;
+				}
+				*buf++ = last;
+			}
+			/* try to match another run of a color */
+			continue;
+		}
+		else {
+			/* run of different pixels, stopping at next pair of matching pixels */
+			while (ptr < ptr_end - 1 && *ptr != *(ptr+1) && *(ptr+1) != *(ptr+2)) {
+				ptr++;
+				ref++;
+			}
+			while (run_start < ptr) {
+				count = ptr - run_start;
+				if (count > 254) {
+					/* stop at 254 to avoid use of padding byte for this chunk */
+					count = 254;
+				}
+
+				if (count < 3) {
+					/* can't do a data copy length of 1 or 2 directly */
+					*buf++ = 1;
+					*buf++ = *run_start++;
+					if (count == 2) {
+						*buf++ = 1;
+						*buf++ = *run_start++;
+					}
+				}
+				else {
+					/* data copy of length 3 to 255 can be done in one encoding */
+					*buf++ = 0;
+					*buf++ = count;
+					extra = count & 1;
+					while (count-- > 0) {
+						*buf++ = *run_start++;
+					}
+					if (extra) *buf++ = 0;
+				}
+			}
+		}
+	}
+
+	if (buf > buf_start) {
+		/* mark end of line */
+		*buf++ = 0;
+		*buf++ = 0;
+	}
+	else {
+		/* no end of line marker when a blank line is encountered */
+		*dy = *dy + 1;
+	}
+	return buf - buf_start;
+}
+
+/* MRLE_CreateInterframe compares the current screen to the reference screen and
+   fills the output buffer with the MRLE encoded differences. It also updates
+   the reference screen to hold the current screen.
+
+   RETURNS: number of encoded bytes, which may be zero if identical to previous
+   frame */
+static int MRLE_CreateInterframe(UBYTE *buf, int bufsize, const UBYTE *source, UBYTE *reference) {
+	UBYTE *buf_start;
+	const UBYTE *ptr;
+	UBYTE *ref;
+	int y;
+	int dy;
+	int size;
+
+	buf_start = buf;
+
+	/* dy is used to keep track of consecutive blank lines encoutered in the line
+	   encoder */
+	dy = 0;
+
+	for (y = (video_top_margin + video_height)-1; y >= video_top_margin; y--) {
+		ptr = source + (y * Screen_WIDTH) + video_left_margin;
+		ref = reference + (y * Screen_WIDTH) + video_left_margin;
+
+		size = MRLE_CompressDelta(buf, ptr, ref, video_width, &dy);
+		buf += size;
+	}
+
+	if (buf > buf_start) {
+		/* mark end of bitmap */
+		*buf++ = 0;
+		*buf++ = 1;
+	}
+
+	return buf - buf_start;
+}
+
+static int MRLE_CreateFrame(const UBYTE *source) {
+	int size;
+
+	if (current_is_keyframe) {
+		size = MRLE_CreateKeyframe(rle_buffer, rle_buffer_size, source);
+	}
+	else {
+		size = MRLE_CreateInterframe(rle_buffer, rle_buffer_size, source, reference_screen);
+	}
+
+	/* save new reference screen */
+	memcpy(reference_screen, Screen_atari, Screen_HEIGHT * Screen_WIDTH);
+
+	return size;
+}
+
 /* AVI_AddVideoFrame adds a video frame to the stream. If an existing video
    frame & audio data exist, save it to the file before starting a new frame.
    Note that AVI_AddVideoFrame and AVI_AddAudioSamples may be called in either
    order, but you must call both video and audio functions before the same
    function again. */
 int AVI_AddVideoFrame(FILE *fp) {
-	if (current_screen_size > 0) {
+	if (current_screen_size >= 0) {
 #ifdef SOUND
 		if (num_streams == 1 || current_audio_samples > 0) {
 #endif
@@ -1143,9 +1437,9 @@ int AVI_AddVideoFrame(FILE *fp) {
 		}
 #endif
 	}
-	else if (current_screen_size < 0
+	else if (current_screen_size < -1
 #ifdef SOUND
-			 || current_audio_samples < 0
+			 || current_audio_samples < -1
 #endif
 			) {
 		/* error condition; force close of file */
@@ -1159,10 +1453,10 @@ int AVI_AddVideoFrame(FILE *fp) {
 			break;
 #endif
 		default:
-			current_screen_size = MRLE_CreateFrame(rle_buffer, rle_buffer_size, (const UBYTE *)Screen_atari);
+			current_screen_size = MRLE_CreateFrame((const UBYTE *)Screen_atari);
 			break;
 	}
-	return current_screen_size > 0;
+	return current_screen_size >= 0;
 }
 
 #ifdef SOUND
@@ -1174,8 +1468,8 @@ int AVI_AddVideoFrame(FILE *fp) {
 int AVI_AddAudioSamples(const UBYTE *buf, int num_samples, FILE *fp) {
 	int size;
 
-	if (current_audio_samples > 0) {
-		if (current_screen_size > 0) {
+	if (current_audio_samples >= 0) {
+		if (current_screen_size >= 0) {
 			if (!AVI_WriteFrame(fp)) {
 				return 0;
 			}
@@ -1185,7 +1479,7 @@ int AVI_AddAudioSamples(const UBYTE *buf, int num_samples, FILE *fp) {
 			return 0;
 		}
 	}
-	else if (current_screen_size < 0 || current_audio_samples < 0) {
+	else if (current_screen_size < -1 || current_audio_samples < -1) {
 		/* error condition; force close of file */
 		return 0;
 	}
@@ -1194,7 +1488,7 @@ int AVI_AddAudioSamples(const UBYTE *buf, int num_samples, FILE *fp) {
 	if (size > audio_buffer_size) {
 		Log_print("AVI write error: audio buffer size too small to hold %d samples", num_samples);
 		/* set error condition */
-		current_audio_samples = -1;
+		current_audio_samples = -2;
 		return 0;
 	}
 	current_audio_samples = num_samples;
@@ -1210,6 +1504,8 @@ static int AVI_WriteIndex(FILE *fp) {
 	int size;
 	int index_size;
 	int bytes_written;
+	ULONG index;
+	int is_keyframe;
 
 	if (frames_written == 0) return 0;
 
@@ -1229,10 +1525,13 @@ static int AVI_WriteIndex(FILE *fp) {
 	fputl(index_size, fp);
 
 	for (i = 0; i < frames_written; i++) {
+		index = frame_indexes[i];
+		is_keyframe = index & 0x80000000 ? 0x10 : 0;
+
 		fputs("00dc", fp); /* stream 0, a compressed video frame */
-		fputl(0x10, fp); /* flags: is a keyframe */
+		fputl(is_keyframe, fp); /* flags: is a keyframe */
 		fputl(offset, fp); /* offset in bytes from start of the 'movi' list */
-		size = frame_indexes[i] & 0xffff;
+		size = index & 0xffff;
 		fputl(size, fp); /* size of video frame */
 		offset += size + 8 + (size % 2); /* make sure to word-align next offset */
 
@@ -1240,7 +1539,7 @@ static int AVI_WriteIndex(FILE *fp) {
 		fputs("01wb", fp); /* stream 1, audio data */
 		fputl(0, fp); /* flags: audio is not a keyframe */
 		fputl(offset, fp); /* offset in bytes from start of the 'movi' list */
-		size = frame_indexes[i] / 0x10000;
+		size = (index / 0x10000) & 0x7fff;
 		fputl(size, fp); /* size of audio data */
 		offset += size + 8 + (size % 2); /* make sure to word-align next offset */
 #endif
@@ -1262,9 +1561,9 @@ int AVI_CloseFile(FILE *fp)
 	int result;
 
 	/* write out final frame if one exists */
-	if (current_screen_size > 0
+	if (current_screen_size >= 0
 #ifdef SOUND
-		&& current_audio_samples > 0
+		&& current_audio_samples >= 0
 #endif
 			) {
 		result = AVI_WriteFrame(fp);
@@ -1298,6 +1597,11 @@ int AVI_CloseFile(FILE *fp)
 	free(rle_buffer);
 	rle_buffer = NULL;
 	rle_buffer_size = 0;
+	if (reference_screen_size > 0) {
+		free(reference_screen);
+		reference_screen = NULL;
+		reference_screen_size = 0;
+	}
 	current_screen_size = -1;
 	free(frame_indexes);
 	frame_indexes = NULL;

--- a/src/file_export.h
+++ b/src/file_export.h
@@ -6,11 +6,7 @@
 #define VIDEO_CODEC_AUTO 0
 #define VIDEO_CODEC_MRLE 1
 #define VIDEO_CODEC_PNG 2
-#ifdef HAVE_LIBPNG
-#define VIDEO_CODEC_BEST_AVAILABLE 2
-#else
 #define VIDEO_CODEC_BEST_AVAILABLE 1
-#endif
 
 int File_Export_Initialise(int *argc, char *argv[]);
 int File_Export_ReadConfig(char *string, char *ptr);
@@ -32,7 +28,6 @@ int WAV_CloseFile(FILE *fp);
 #endif
 
 #ifdef AVI_VIDEO_RECORDING
-int MRLE_CreateFrame(UBYTE *buf, int bufsize, const UBYTE *source);
 FILE *AVI_OpenFile(const char *szFileName);
 int AVI_CloseFile(FILE *fp);
 int AVI_AddVideoFrame(FILE *fp);

--- a/src/file_export.h
+++ b/src/file_export.h
@@ -3,6 +3,7 @@
 
 #include "atari.h"
 
+#define VIDEO_CODEC_AUTO 0
 #define VIDEO_CODEC_MRLE 1
 #define VIDEO_CODEC_PNG 2
 #ifdef HAVE_LIBPNG
@@ -12,6 +13,8 @@
 #endif
 
 int File_Export_Initialise(int *argc, char *argv[]);
+int File_Export_ReadConfig(char *string, char *ptr);
+void File_Export_WriteConfig(FILE *fp);
 
 void fputw(UWORD, FILE *fp);
 void fputl(ULONG, FILE *fp);

--- a/src/libatari800/api.c
+++ b/src/libatari800/api.c
@@ -97,7 +97,7 @@ int libatari800_init(int argc, char **argv) {
 		}
 		argc = i;
 	}
-	if ((argc == 0) || ((argc > 0) && argv[0] && (strcmp(argv[0], "atari800") != 0))) {
+	if ((argc == 0) || ((argc > 0) && argv[0] && (!Util_striendswith(argv[0], "atari800")))) {
 		argv_alloced = argc + 1;
 		argv_ptr = (Util_malloc(sizeof(char *) * argv_alloced));
 		argv_ptr[0] = NULL;

--- a/src/libatari800/api.c
+++ b/src/libatari800/api.c
@@ -55,6 +55,9 @@
 jmp_buf libatari800_cpu_crash;
 #endif
 
+/* global variable indicating that BRK instruction should exit emulation */
+int libatari800_continue_on_brk = 0;
+
 /* global variable indicating last error code */
 int libatari800_error_code;
 
@@ -149,6 +152,22 @@ const char *libatari800_error_message() {
 		return unknown_error;
 	}
 	return error_messages[libatari800_error_code];
+}
+
+
+/** Set whether encountering a BRK instruction exits emulation.
+ * 
+ * Choose what happens when a BRK instruction is encountered. Most often this will lead
+ * to the program inside the emulator failing and forcing the emulator into a lockup
+ * condition. But some programs trap the BRK instruction to implement extra functionality
+ * like a debugger.
+ * 
+ * @param cont if True, the emulation will continue without notification when a BRK is
+ * encountered. If False, emulation immediately exits with the error code
+ * LIBATARI800_BRK_INSTRUCTION
+ */
+void libatari800_continue_emulation_on_brk(int cont) {
+	libatari800_continue_on_brk = cont;
 }
 
 

--- a/src/libatari800/cpu_crash.h
+++ b/src/libatari800/cpu_crash.h
@@ -12,4 +12,6 @@ extern jmp_buf libatari800_cpu_crash;
 
 #include "libatari800/libatari800.h"
 
+extern int libatari800_continue_on_brk;
+
 #endif /* LIBATARI800_API_H_ */

--- a/src/libatari800/init.c
+++ b/src/libatari800/init.c
@@ -27,11 +27,24 @@
 #include <string.h>
 
 #include "atari.h"
+#include "cfg.h"
+#include "util.h"
 #include "libatari800/init.h"
+#include "libatari800/cpu_crash.h"
 
 
 int LIBATARI800_Initialise(void)
 {
+	libatari800_continue_on_brk = FALSE;
+	return TRUE;
+}
+
+int LIBATARI800_ReadConfig(char *option, char *parameters)
+{
+	if (strcmp(option, "LIBATARI800_CONTINUE_ON_BRK") == 0)
+		return (libatari800_continue_on_brk = Util_sscanbool(parameters)) != -1;
+	else
+		return FALSE;
 	return TRUE;
 }
 

--- a/src/libatari800/input.c
+++ b/src/libatari800/input.c
@@ -150,11 +150,6 @@ int PLATFORM_Keyboard(void)
 		}
 	}
 
-	/* Host Caps Lock will make lastuni switch case, so prevent this*/
-    if(lastkey>='A' && lastkey <= 'Z' && !INPUT_key_shift) lastkey += 0x20;
-    if(lastkey>='a' && lastkey <= 'z' && INPUT_key_shift) lastkey -= 0x20;
-	/* Uses only UNICODE translation, no shift states (this was added to
-	 * support non-US keyboard layouts)*/
 	/* input.c takes care of removing invalid shift+control keys */
 	switch (lastkey) {
 	case 1:
@@ -210,57 +205,57 @@ int PLATFORM_Keyboard(void)
 	case 26:
 		return AKEY_CTRL_z|shiftctrl;
 	case 'A':
-		return AKEY_A;
+		return AKEY_A|shiftctrl;
 	case 'B':
-		return AKEY_B;
+		return AKEY_B|shiftctrl;
 	case 'C':
-		return AKEY_C;
+		return AKEY_C|shiftctrl;
 	case 'D':
-		return AKEY_D;
+		return AKEY_D|shiftctrl;
 	case 'E':
-		return AKEY_E;
+		return AKEY_E|shiftctrl;
 	case 'F':
-		return AKEY_F;
+		return AKEY_F|shiftctrl;
 	case 'G':
-		return AKEY_G;
+		return AKEY_G|shiftctrl;
 	case 'H':
-		return AKEY_H;
+		return AKEY_H|shiftctrl;
 	case 'I':
-		return AKEY_I;
+		return AKEY_I|shiftctrl;
 	case 'J':
-		return AKEY_J;
+		return AKEY_J|shiftctrl;
 	case 'K':
-		return AKEY_K;
+		return AKEY_K|shiftctrl;
 	case 'L':
-		return AKEY_L;
+		return AKEY_L|shiftctrl;
 	case 'M':
-		return AKEY_M;
+		return AKEY_M|shiftctrl;
 	case 'N':
-		return AKEY_N;
+		return AKEY_N|shiftctrl;
 	case 'O':
-		return AKEY_O;
+		return AKEY_O|shiftctrl;
 	case 'P':
-		return AKEY_P;
+		return AKEY_P|shiftctrl;
 	case 'Q':
-		return AKEY_Q;
+		return AKEY_Q|shiftctrl;
 	case 'R':
-		return AKEY_R;
+		return AKEY_R|shiftctrl;
 	case 'S':
-		return AKEY_S;
+		return AKEY_S|shiftctrl;
 	case 'T':
-		return AKEY_T;
+		return AKEY_T|shiftctrl;
 	case 'U':
-		return AKEY_U;
+		return AKEY_U|shiftctrl;
 	case 'V':
-		return AKEY_V;
+		return AKEY_V|shiftctrl;
 	case 'W':
-		return AKEY_W;
+		return AKEY_W|shiftctrl;
 	case 'X':
-		return AKEY_X;
+		return AKEY_X|shiftctrl;
 	case 'Y':
-		return AKEY_Y;
+		return AKEY_Y|shiftctrl;
 	case 'Z':
-		return AKEY_Z;
+		return AKEY_Z|shiftctrl;
 	case ':':
 		return AKEY_COLON;
 	case '!':
@@ -296,57 +291,57 @@ int PLATFORM_Keyboard(void)
 	case '>':
 		return AKEY_GREATER;
 	case 'a':
-		return AKEY_a;
+		return AKEY_a|shiftctrl;
 	case 'b':
-		return AKEY_b;
+		return AKEY_b|shiftctrl;
 	case 'c':
-		return AKEY_c;
+		return AKEY_c|shiftctrl;
 	case 'd':
-		return AKEY_d;
+		return AKEY_d|shiftctrl;
 	case 'e':
-		return AKEY_e;
+		return AKEY_e|shiftctrl;
 	case 'f':
-		return AKEY_f;
+		return AKEY_f|shiftctrl;
 	case 'g':
-		return AKEY_g;
+		return AKEY_g|shiftctrl;
 	case 'h':
-		return AKEY_h;
+		return AKEY_h|shiftctrl;
 	case 'i':
-		return AKEY_i;
+		return AKEY_i|shiftctrl;
 	case 'j':
-		return AKEY_j;
+		return AKEY_j|shiftctrl;
 	case 'k':
-		return AKEY_k;
+		return AKEY_k|shiftctrl;
 	case 'l':
-		return AKEY_l;
+		return AKEY_l|shiftctrl;
 	case 'm':
-		return AKEY_m;
+		return AKEY_m|shiftctrl;
 	case 'n':
-		return AKEY_n;
+		return AKEY_n|shiftctrl;
 	case 'o':
-		return AKEY_o;
+		return AKEY_o|shiftctrl;
 	case 'p':
-		return AKEY_p;
+		return AKEY_p|shiftctrl;
 	case 'q':
-		return AKEY_q;
+		return AKEY_q|shiftctrl;
 	case 'r':
-		return AKEY_r;
+		return AKEY_r|shiftctrl;
 	case 's':
-		return AKEY_s;
+		return AKEY_s|shiftctrl;
 	case 't':
-		return AKEY_t;
+		return AKEY_t|shiftctrl;
 	case 'u':
-		return AKEY_u;
+		return AKEY_u|shiftctrl;
 	case 'v':
-		return AKEY_v;
+		return AKEY_v|shiftctrl;
 	case 'w':
-		return AKEY_w;
+		return AKEY_w|shiftctrl;
 	case 'x':
-		return AKEY_x;
+		return AKEY_x|shiftctrl;
 	case 'y':
-		return AKEY_y;
+		return AKEY_y|shiftctrl;
 	case 'z':
-		return AKEY_z;
+		return AKEY_z|shiftctrl;
 	case ';':
 		return AKEY_SEMICOLON;
 	case '0':

--- a/src/libatari800/libatari800.h
+++ b/src/libatari800/libatari800.h
@@ -21,6 +21,80 @@
 #define TRUE   1
 #endif
 
+/* Special keys for use as input_template_t.keycode values. These defines are
+   from akey.h in the atari800 source, but are copied here as the internal
+   headers aren't available when libatari800 is installed as a library. */
+#define AKEY_HELP 0x11
+#define AKEY_DOWN 0x8f
+#define AKEY_LEFT 0x86
+#define AKEY_RIGHT 0x87
+#define AKEY_UP 0x8e
+#define AKEY_BACKSPACE 0x34
+#define AKEY_DELETE_CHAR 0xb4
+#define AKEY_DELETE_LINE 0x74
+#define AKEY_INSERT_CHAR 0xb7
+#define AKEY_INSERT_LINE 0x77
+#define AKEY_ESCAPE 0x1c
+#define AKEY_ATARI 0x27
+#define AKEY_CAPSLOCK 0x7c
+#define AKEY_CAPSTOGGLE 0x3c
+#define AKEY_TAB 0x2c
+#define AKEY_SETTAB 0x6c
+#define AKEY_CLRTAB 0xac
+#define AKEY_RETURN 0x0c
+#define AKEY_SPACE 0x21
+#define AKEY_EXCLAMATION 0x5f
+#define AKEY_DBLQUOTE 0x5e
+#define AKEY_HASH 0x5a
+#define AKEY_DOLLAR 0x58
+#define AKEY_PERCENT 0x5d
+#define AKEY_AMPERSAND 0x5b
+#define AKEY_QUOTE 0x73
+#define AKEY_AT 0x75
+#define AKEY_PARENLEFT 0x70
+#define AKEY_PARENRIGHT 0x72
+#define AKEY_LESS 0x36
+#define AKEY_GREATER 0x37
+#define AKEY_EQUAL 0x0f
+#define AKEY_QUESTION 0x66
+#define AKEY_MINUS 0x0e
+#define AKEY_PLUS 0x06
+#define AKEY_ASTERISK 0x07
+#define AKEY_SLASH 0x26
+#define AKEY_COLON 0x42
+#define AKEY_SEMICOLON 0x02
+#define AKEY_COMMA 0x20
+#define AKEY_FULLSTOP 0x22
+#define AKEY_UNDERSCORE 0x4e
+#define AKEY_BRACKETLEFT 0x60
+#define AKEY_BRACKETRIGHT 0x62
+#define AKEY_CIRCUMFLEX 0x47
+#define AKEY_BACKSLASH 0x46
+#define AKEY_BAR 0x4f
+#define AKEY_CLEAR (AKEY_SHFT | AKEY_LESS)
+#define AKEY_CARET (AKEY_SHFT | AKEY_ASTERISK)
+#define AKEY_F1 0x03
+#define AKEY_F2 0x04
+#define AKEY_F3 0x13
+#define AKEY_F4 0x14
+
+/* 5200 key codes */
+#define AKEY_5200_START 0x39
+#define AKEY_5200_PAUSE 0x31
+#define AKEY_5200_RESET 0x29
+#define AKEY_5200_0 0x25
+#define AKEY_5200_1 0x3f
+#define AKEY_5200_2 0x3d
+#define AKEY_5200_3 0x3b
+#define AKEY_5200_4 0x37
+#define AKEY_5200_5 0x35
+#define AKEY_5200_6 0x33
+#define AKEY_5200_7 0x2f
+#define AKEY_5200_8 0x2d
+#define AKEY_5200_9 0x2b
+#define AKEY_5200_HASH 0x23
+#define AKEY_5200_ASTERISK 0x27
+
 typedef struct {
     UBYTE keychar;
     UBYTE keycode;

--- a/src/libatari800/libatari800.h
+++ b/src/libatari800/libatari800.h
@@ -270,6 +270,8 @@ int libatari800_init(int argc, char **argv);
 
 const char *libatari800_error_message();
 
+void libatari800_continue_emulation_on_brk(int cont);
+
 void libatari800_clear_input_array(input_template_t *input);
 
 int libatari800_next_frame(input_template_t *input);

--- a/src/libatari800/main.c
+++ b/src/libatari800/main.c
@@ -66,7 +66,7 @@
 
 int PLATFORM_Configure(char *option, char *parameters)
 {
-	return TRUE;
+	return LIBATARI800_ReadConfig(option, parameters);
 }
 
 void PLATFORM_ConfigSave(FILE *fp)

--- a/src/screen.c
+++ b/src/screen.c
@@ -419,15 +419,6 @@ void Screen_Draw1200LED(void)
 }
 
 #ifndef DREAMCAST
-static int striendswith(const char *s1, const char *s2)
-{
-	int pos;
-	pos = strlen(s1) - strlen(s2);
-	if (pos < 0)
-		return 0;
-	return Util_stricmp(s1 + pos, s2) == 0;
-}
-
 int Screen_SaveScreenshot(const char *filename, int interlaced)
 {
 	int is_png;
@@ -435,10 +426,10 @@ int Screen_SaveScreenshot(const char *filename, int interlaced)
 	ULONG *main_screen_atari;
 	UBYTE *ptr1;
 	UBYTE *ptr2;
-	if (striendswith(filename, ".pcx"))
+	if (Util_striendswith(filename, ".pcx"))
 		is_png = 0;
 #ifdef HAVE_LIBPNG
-	else if (striendswith(filename, ".png"))
+	else if (Util_striendswith(filename, ".png"))
 		is_png = 1;
 #endif
 	else

--- a/src/util.c
+++ b/src/util.c
@@ -88,6 +88,15 @@ int Util_stricmp(const char *str1, const char *str2)
 }
 #endif
 
+int Util_striendswith(const char *s1, const char *s2)
+{
+	int pos;
+	pos = strlen(s1) - strlen(s2);
+	if (pos < 0)
+		return 0;
+	return Util_stricmp(s1 + pos, s2) == 0;
+}
+
 int Util_strnicmp(const char *str1, const char *str2, size_t size)
 {
 	int retval = 0;

--- a/src/util.h
+++ b/src/util.h
@@ -34,6 +34,9 @@ int Util_stricmp(const char *str1, const char *str2);
 #define Util_stricmp stricmp
 #endif
 
+/* Returns TRUE if str1 ends with the characters in str2, regardless of case. */
+int Util_striendswith(const char *str1, const char *str2);
+
 /* Same as strncasecmp(), compare 2 strings, limited to size. */
 int Util_strnicmp(const char *str1, const char *str2, size_t size);
 


### PR DESCRIPTION
Added inter-frames to the run-length encoding codec, greatly improving compression ratios. You can record Jumpman for 45 hours! OK, that's without audio, but still over 10 hours with audio in a 4GB file.

Made it the default codec now, because it's compatible with more players, uses less CPU to compress, and compresses better in most cases over the PNG video codec.

Also:
* added `-keyframe-interval` command line option
* added config file support for file_export arguments
* updated man page
* fixed libatari800 key handling
* moved striendswith to util.c so it can be reused by libatari800
