### PR TITLE
-stereo/-nostereo command line fix & minor documentation stuff

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -195,9 +195,20 @@ int ARTIFACT_Initialise(int *argc, char *argv[])
 
 		else {
 			if (strcmp(argv[i], "-help") == 0) {
-				Log_print("\t-ntsc-artif none|ntsc-old|ntsc-new|ntsc-full");
+				Log_print("\t-ntsc-artif none|ntsc-old|ntsc-new"
+#if NTSC_FILTER
+						"|ntsc-full"
+#endif
+				);
 				Log_print("\t                 Select video artifacts for NTSC");
-				Log_print("\t-pal-artif none|pal-simple|pal-accu");
+				Log_print("\t-pal-artif none"
+#ifndef NO_SIMPLE_PAL_BLENDING
+						"|pal-simple"
+#endif
+#ifdef PAL_BLENDING
+						"|pal-blend"
+#endif
+				);
 				Log_print("\t                 Select video artifacts for PAL");
 			}
 			argv[j++] = argv[i];

--- a/src/atari.c
+++ b/src/atari.c
@@ -567,9 +567,15 @@ int Atari800_Initialise(int *argc, char *argv[])
 #ifdef STEREO_SOUND
 		else if (strcmp(argv[i], "-stereo") == 0) {
 			POKEYSND_stereo_enabled = TRUE;
+#ifdef SOUND_THIN_API
+			Sound_desired.channels = 2;
+#endif /* SOUND_THIN_API */
 		}
 		else if (strcmp(argv[i], "-nostereo") == 0) {
 			POKEYSND_stereo_enabled = FALSE;
+#ifdef SOUND_THIN_API
+			Sound_desired.channels = 1;
+#endif /* SOUND_THIN_API */
 		}
 #endif /* STEREO_SOUND */
 		else if (strcmp(argv[i], "-turbo") == 0) {

--- a/src/atari800.man
+++ b/src/atari800.man
@@ -1100,6 +1100,18 @@ Deactivates showing output of an 80 column hardware.
 .B \-nojoystick
 Do not initialize SDL joysticks
 .TP
+.B \-joy0hat
+Use hat of joystick 0 rather than the axis for joystick movement.
+.TP
+.B \-joy1hat
+Use hat of joystick 1 rather than the axis for joystick movement.
+.TP
+.B \-joy2hat
+Use hat of joystick 2 rather than the axis for joystick movement.
+.TP
+.B \-joy3hat
+Use hat of joystick 3 rather than the axis for joystick movement.
+.TP
 .BI \-joy0\  path\-to\-device
 Define path to device used in LPTjoy 0. Available on linux-ia32 only.
 .TP

--- a/src/atari800.man
+++ b/src/atari800.man
@@ -773,6 +773,12 @@ Disable sound
 Set sound output frequency in Hz.
 The default is 44100 Hz.
 .TP
+.B \-stereo
+Enable stereo sound
+.TP
+.B \-nostereo
+Disable stereo sound
+.TP
 .B \-audio16
 Set sound output format to 16-bit
 .TP

--- a/src/sdl/input.c
+++ b/src/sdl/input.c
@@ -1356,10 +1356,10 @@ int SDL_INPUT_Initialise(int *argc, char *argv[])
 			if (strcmp(argv[i], "-help") == 0) {
 				help_only = TRUE;
 				Log_print("\t-nojoystick      Disable joystick");
-                                Log_print("\t-joy0hat         Use hat of joystick 0");
-                                Log_print("\t-joy1hat         Use hat of joystick 1");
-                                Log_print("\t-joy2hat         Use hat of joystick 1");
-                                Log_print("\t-joy3hat         Use hat of joystick 1");
+				Log_print("\t-joy0hat         Use hat of joystick 0");
+				Log_print("\t-joy1hat         Use hat of joystick 1");
+				Log_print("\t-joy2hat         Use hat of joystick 2");
+				Log_print("\t-joy3hat         Use hat of joystick 3");
 #ifdef LPTJOY
 				Log_print("\t-joy0 <pathname> Select LPTjoy0 device");
 				Log_print("\t-joy1 <pathname> Select LPTjoy1 device");


### PR DESCRIPTION
Mostly documentation fixes except for the -stereo/-nostereo fix: the setting in the config file wasn't able to be overridden by the command line argument. (At least on the SDL port.)