### PR TITLE
Added file export error checking and UI improvements

### DIFF
--- a/DOC/INSTALL
+++ b/DOC/INSTALL
@@ -56,8 +56,13 @@ many others with a little work):-
 11. Static library version: libatari800
 
 Installed zlib (compression library) enables building the emulator with
-compressed statesave images support. Additionally installed libpng
-makes the emulator capable of generating screenshots in the PNG format.
+compressed statesave images support.
+
+Installed libpng makes the emulator capable of generating screenshots in
+the PNG format.
+
+Installed libmp3lame enables MP3 audio to be saved in video and audio
+files.
 
 Building the Emulator on most platforms
 ---------------------------------------

--- a/DOC/README
+++ b/DOC/README
@@ -139,7 +139,9 @@ o Atari palette read from a file or calculated basing on user-defined
 
 o Screen snapshots (normal and interlaced) to PCX and PNG files.
 
-o Sound output may be written to WAV files.
+o Sound output may be written to WAV or MP3 files.
+
+o MP3 sound support if libmp3lame is available.
 
 o Emulator video and audio may be recorded to AVI files for playback in
   video players or uploading to YouTube or other online platforms.

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,52 @@ AC_PROG_INSTALL
 AC_PROG_RANLIB
 AC_CHECK_TOOLS(WINDRES, [windres], :)
 
+
+dnl The A8_ADD_INCLUDE_PATH macro searches for include files in subdirectories of
+dnl a list of paths plus standard include paths. E.g. /usr/include/PACKAGE/package.h
+dnl is not found automatically because only /usr/include is searched, not
+dnl /usr/include/PACKAGE. This function takes standard include paths plus any
+dnl additional include paths in argument $3 and for each path there, looks in
+dnl any existing subdirs specified in argument $4. If found, the subdir is added
+dnl to the $CPPFLAGS variable. If not found in any path combination, the code in
+dnl $5 is executed.
+dnl         $1    = the name of the feature for informational messages
+dnl         $2    = header file to use as test for presense
+dnl         $3    = the list of possible include directory paths to use as prefixes
+dnl                 to the combined path
+dnl         $4    = the list of possible include subdirectories
+dnl         $5    = code to execute if include not found
+AC_DEFUN([A8_ADD_INCLUDE_PATH], [
+    AC_CHECK_HEADER([$2],[],[
+        _a8_saved_cppflags=$CPPFLAGS
+        _a8_found=no
+        for _a8_dir in ${prefix}/include $3; do
+            for _a8_subdir in $4; do
+                _a8_fulldir="$_a8_dir/$_a8_subdir"
+                test ! -d "$_a8_fulldir" && continue
+                AC_MSG_CHECKING([for $1 headers in])
+                AC_MSG_RESULT([$_a8_fulldir])
+                AS_UNSET([AS_TR_SH([ac_cv_header_$2])])
+                CPPFLAGS="$_a8_saved_cppflags -I$_a8_fulldir"
+                AC_CHECK_HEADER([$2],[_a8_found="yes"; break],[])
+            done
+            if [[ "$_a8_found" = "yes" ]]; then
+                break
+            fi
+        done
+        if [[ "$_a8_found" != "yes" ]]; then
+            CPPFLAGS=$_a8_saved_cppflags
+            $5
+        fi
+        AS_UNSET(_a8_found)
+        AS_UNSET(_a8_dir)
+        AS_UNSET(_a8_subdir)
+        AS_UNSET(_a8_fulldir)
+        AS_UNSET(_a8_saved_cppflags)
+    ])
+])
+
+
 AC_DEFUN([AM_PROG_AS], []) dnl dummy to make automake happy, since vasm is used instead
 CCAS=vasm
 CCASFLAGS="-quiet -devpac -opt-allbra -Faout"
@@ -1057,12 +1103,41 @@ if [[ "$with_sound" != no ]]; then
               VOICEBOX,[Define to emulate the Alien Group Voice Box.]
              )
 
-    dnl Need SUPPORTS_LIBMP3LAME shell variable for mp3 audio codec test below
-	AC_CHECK_LIB(mp3lame,lame_init,[LIBS="-lmp3lame $LIBS"; SUPPORTS_LIBMP3LAME=yes],[SUPPORTS_LIBMP3LAME=no])
     supported_audio_codecs="pcm adpcm mulaw"
-    if [[ "$SUPPORTS_LIBMP3LAME" = "yes" ]]; then
-        AC_DEFINE(HAVE_LIBMP3LAME,1,[Supports LAME mp3 audio compression library.])
-        supported_audio_codecs="$supported_audio_codecs mp3"
+    AC_ARG_WITH(mp3,
+        [AC_HELP_STRING(--with-mp3@<:@=no|yes|lame@:>@,[Select mp3 audio @<:@default=check@:>@])],
+        [
+            case "$withval" in
+                no | yes | check | lame)
+                    ;;
+                *)
+                    AC_MSG_ERROR([unrecognized value for --with-mp3: "$withval"])
+                    ;;
+            esac
+        ],
+        [with_mp3=check])
+    if [[ "$with_mp3" != "no" ]]; then
+        if [[ "$with_mp3" = check -o "$with_mp3" = yes -o "$with_mp3" = lame ]]; then
+            AC_CHECK_LIB(mp3lame, lame_init, [
+                A8_ADD_INCLUDE_PATH([lame],[lame.h],[/usr/include /usr/local/include],[lame],[
+                    if [[ "$with_mp3" = yes -o "$with_mp3" = "lame" ]]; then
+                        AC_MSG_ERROR([lame.h not found, modify CPPFLAGS or use --with-mp3=check])
+                    fi
+                    with_mp3=no
+                ])
+                if [[ $with_mp3 != no ]]; then
+                    LIBS="-lmp3lame $LIBS"
+                    AC_DEFINE(AUDIO_CODEC_MP3,1,[Supports mp3 audio])
+                    supported_audio_codecs="$supported_audio_codecs mp3"
+                    with_mp3="libmp3lame"
+                fi
+            ], [
+                if [[ "$with_mp3" = yes -o "$with_mp3" = "lame" ]]; then
+                    AC_MSG_ERROR([unable to find libmp3lame, modify LDFLAGS or use --with-mp3=check])
+                fi
+                with_mp3="no"
+            ])
+        fi
     fi
 else
     WANT_NONLINEAR_MIXING="no"
@@ -1074,13 +1149,13 @@ else
     WANT_SERIO_SOUND="no"
     WANT_CLIP_SOUND="no"
     WANT_PBI_XLD_SOUND="no"
-    SUPPORTS_LIBMP3LAME="no"
+    WANT_AUDIO_CODEC_MP3="no"
 fi
 AM_CONDITIONAL([WANT_PBI_XLD], test "$WANT_PBI_XLD" = "yes")
 AM_CONDITIONAL([WANT_VOICEBOX], test "$WANT_VOICEBOX" = "yes")
 AM_CONDITIONAL([WANT_PBI_XLD_OR_VOICEBOX], test "$WANT_PBI_XLD" = "yes" -o "$WANT_VOICEBOX" = "yes")
 AM_CONDITIONAL([WANT_PBI_MIO_OR_BB], test "$WANT_PBI_MIO" = "yes" -o "$WANT_PBI_BB" = "yes")
-AM_CONDITIONAL([WITH_AUDIO_CODEC_MP3], test "$SUPPORTS_LIBMP3LAME" = "yes")
+AM_CONDITIONAL([WITH_AUDIO_CODEC_MP3], test "$with_mp3" != "no")
 
 if [[ "$with_video" != no -a "$WANT_CURSES_BASIC" != yes ]]; then
     have_bitmapped_screen=yes
@@ -1385,6 +1460,9 @@ if [[ "$with_sound" != no ]]; then
     echo "    Using 1400XL/1450XLD emulation?...: $WANT_PBI_XLD"
     echo "    Using sound clipping?.............: $WANT_CLIP_SOUND"
     echo "    Supported audio codecs............: $supported_audio_codecs"
+    if [[ "$with_mp3" != "no" ]]; then
+        echo "        Library for mp3 audio.........: $with_mp3"
+    fi
 else
     echo "    (Sound sub-options disabled)"
 fi

--- a/src/atari800.man
+++ b/src/atari800.man
@@ -796,6 +796,13 @@ Set filename pattern for audio recordings.
 Use to override the default pattern of \fIatari###.wav\fR which produces
 \fIatari000.wav\fR, \fIatari001.wav\fR etc. filenames.
 Hashes are replaced with raising numbers.
+
+Note that WAV format files can support all audio codecs, including MP3,
+but many programs assume WAV files contain only PCM audio.
+
+If MP3 support was enabled when compiling the emulator, and MP3 audio is
+selected using the \fB\-acodec mp3\fR option below, the default pattern
+will be \fIatari###.mp3\fR to save in MP3 format files.
 .TP
 \fB\-acodec auto\fR|\fBpcm\fR|\fBmp3\fR|\fBmulaw\fR|\fBpcm_mulaw\fR|\fBadpcm\fR|\fBadpcm_ima_wav\fR|\fBadpcm_yahama\fR|\fBadpcm_ms\fR
 Select the audio codec used when saving to AVI or WAV files. Some codecs are
@@ -817,8 +824,7 @@ large audio files.
 .B mp3
 Use MP3 encoding. Lossy; only available with 16-bit audio, and provides the best
 possible quality of all the lossy codecs while also using the least storage space.
-This codec is only available if the libmp3lame library is available when
-compiling the emulator.
+This codec is only available if MP3 support is enabled when compiling the emulator.
 .TP
 .B mulaw
 Use mu-law encoding. Lossy; only available with 16-bit audio, and provides 2x
@@ -856,8 +862,8 @@ are available: 8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100 and 48000.
 As with bitrate, higher numbers mean better quality and larger files.
 .TP
 .BI \-aq\  num
-Set the MP3 compression algorithm quality 0-9 (default 4). 0 means fast but
-reduced quality, 9 uses the slowest algorithms to try to increase quality.
+Set the MP3 audio compression algorithm quality 0-9 (default 4). 0 means reduced
+quality but fast, 9 uses the slowest algorithms to try to increase quality.
 Does not affect storage space.
 .TP
 .BI \-snd\-buflen\  ms
@@ -1724,7 +1730,8 @@ The MP3 codec is the best choice of a lossy codec, as paramaters can be tuned
 to generate high quality audio for different situations. An audio bitrate of
 128kbps (the \fB-ab 128\fR option) results in high quality audio at about an
 8x reduction in storage space over PCM audio. The MP3 codec is a compile-time
-option and requires the libmp3lame library.
+option, and will be included automatically if the libmp3lame library is found
+during compilation.
 .PP
 The remaining lossy codecs should not be considered unless the MP3 codec is
 not available. In most cases they produce reasonable quality, without many
@@ -1735,14 +1742,14 @@ audio distortion in some instances.
 The mu-law codec uses a logarithmic scale to convert 16 bit samples into 8 bits
 of data, resulting in half the size of 16 bit PCM audio. This codec does not
 work with 8 bit audio. Waveform analysis shows the acoustic quality is similar
-to a 192kbps MP3 file, although the MP3 would be half the size. Surprisingly,
+to a 192kbps MP3 file, although the MP3 is half the size. Surprisingly,
 in many cases the acoustic quality of mu-law can be better than 8 bit PCM samples
 even though it takes the same storage space.
 .PP
-Adaptive differential pulse-code modulation (ADPCM) also requires 16 bit audio.
-It encodes differences between successive samples into 4 bits, therefore the
+Adaptive differential pulse-code modulation (ADPCM) encodes differences between
+successive 16 bit audio samples into 4 bits, therefore the
 output is one quarter of the size of the PCM codec. The acoustic quality is
-similar to a 64kbps MP3 file, although the MP3 would be 3x smaller. Audio
+similar to a 64kbps MP3 file, although the MP3 is 3x smaller. Audio
 distortio may be audible under certain conditions, like high volume
 square waves.
 .PD 1

--- a/src/codecs/audio.h
+++ b/src/codecs/audio.h
@@ -54,8 +54,8 @@ typedef int (*AUDIO_CODEC_Flush)(float duration);
    success, or zero on error. */
 typedef int (*AUDIO_CODEC_End)(void);
 
-#define AUDIO_CODEC_FLAG_PCM 0
 #define AUDIO_CODEC_FLAG_VBR_POSSIBLE 1
+#define AUDIO_CODEC_FLAG_SUPPORTS_8_BIT_SAMPLES 2
 
 typedef struct {
     char *codec_id;
@@ -76,7 +76,7 @@ extern AUDIO_OUT_t *audio_out;
 extern int audio_buffer_size;
 extern UBYTE *audio_buffer;
 
-#ifdef HAVE_LIBMP3LAME
+#ifdef AUDIO_CODEC_MP3
 extern int audio_param_bitrate;
 extern int audio_param_samplerate;
 extern int audio_param_quality;
@@ -85,6 +85,7 @@ extern int audio_param_quality;
 int CODECS_AUDIO_Initialise(int *argc, char *argv[]);
 int CODECS_AUDIO_ReadConfig(char *string, char *ptr);
 void CODECS_AUDIO_WriteConfig(FILE *fp);
+int CODECS_AUDIO_CheckType(char *codec_id);
 int CODECS_AUDIO_Init(void);
 void CODECS_AUDIO_End(void);
 

--- a/src/codecs/audio_adpcm.c
+++ b/src/codecs/audio_adpcm.c
@@ -206,10 +206,8 @@ static int reserve_buffers(void)
 	return out.block_align;
 }
 
-static int init_common(int sample_rate, float fps, int sample_size, int num_channels)
+static void init_common(int sample_rate, float fps, int sample_size, int num_channels)
 {
-	if (sample_size < 2)
-		return 0;
 	out.sample_rate = sample_rate;
 	out.sample_size = 1;
 	out.bits_per_sample = 4;
@@ -222,13 +220,11 @@ static int init_common(int sample_rate, float fps, int sample_size, int num_chan
 	out.extra_data_size = 0;
 
 	final_duration = 0.0;
-	return 1;
 }
 
 static int ADPCM_Init_IMA(int sample_rate, float fps, int sample_size, int num_channels)
 {
-	if (!init_common(sample_rate, fps, sample_size, num_channels))
-		return -1;
+	init_common(sample_rate, fps, sample_size, num_channels);
 
 	format_type = FORMAT_IMA;
 	samples_per_block = (out.block_align - 4 * num_channels) * 8 / (4 * num_channels) + 1;
@@ -245,8 +241,7 @@ static int ADPCM_Init_MS(int sample_rate, float fps, int sample_size, int num_ch
 	int i;
 	UBYTE *extra;
 
-	if (!init_common(sample_rate, fps, sample_size, num_channels))
-		return -1;
+	init_common(sample_rate, fps, sample_size, num_channels);
 
 	out.extra_data_size = 32;
 	extra = out.extra_data;
@@ -268,8 +263,7 @@ static int ADPCM_Init_MS(int sample_rate, float fps, int sample_size, int num_ch
 
 static int ADPCM_Init_Yamaha(int sample_rate, float fps, int sample_size, int num_channels)
 {
-	if (!init_common(sample_rate, fps, sample_size, num_channels))
-		return -1;
+	init_common(sample_rate, fps, sample_size, num_channels);
 
 	format_type = FORMAT_YAMAHA;
 	samples_per_block = (out.block_align * 2) / num_channels;
@@ -461,7 +455,7 @@ AUDIO_CODEC_t Audio_Codec_ADPCM = {
 	"DVI IMA ADPCM",
 	{1, 0, 0, 0}, /* fourcc */
 	FORMAT_IMA, /* format type */
-	AUDIO_CODEC_FLAG_PCM,
+	0, /* flags */
 	&ADPCM_Init_IMA,
 	&ADPCM_AudioOut,
 	&ADPCM_CreateFrame,
@@ -475,7 +469,7 @@ AUDIO_CODEC_t Audio_Codec_ADPCM_IMA = {
 	"DVI IMA ADPCM",
 	{1, 0, 0, 0}, /* fourcc */
 	FORMAT_IMA, /* format type */
-	AUDIO_CODEC_FLAG_PCM,
+	0, /* flags */
 	&ADPCM_Init_IMA,
 	&ADPCM_AudioOut,
 	&ADPCM_CreateFrame,
@@ -489,7 +483,7 @@ AUDIO_CODEC_t Audio_Codec_ADPCM_MS = {
 	"Microsoft ADPCM",
 	{1, 0, 0, 0}, /* fourcc */
 	FORMAT_MS, /* format type */
-	AUDIO_CODEC_FLAG_PCM,
+	0, /* flags */
 	&ADPCM_Init_MS,
 	&ADPCM_AudioOut,
 	&ADPCM_CreateFrame,
@@ -503,7 +497,7 @@ AUDIO_CODEC_t Audio_Codec_ADPCM_YAMAHA = {
 	"Yamaha ADPCM",
 	{1, 0, 0, 0}, /* fourcc */
 	FORMAT_YAMAHA, /* format type */
-	AUDIO_CODEC_FLAG_PCM,
+	0, /* flags */
 	&ADPCM_Init_Yamaha,
 	&ADPCM_AudioOut,
 	&ADPCM_CreateFrame,

--- a/src/codecs/audio_mulaw.c
+++ b/src/codecs/audio_mulaw.c
@@ -87,8 +87,6 @@ static int MULAW_Init(int sample_rate, float fps, int sample_size, int num_chann
 {
 	int comp_size;
 
-	if (sample_size < 2)
-		return -1;
 	out.sample_rate = sample_rate;
 	out.sample_size = 1;
 	out.bits_per_sample = 8;
@@ -181,7 +179,7 @@ AUDIO_CODEC_t Audio_Codec_MULAW = {
 	"mu-law 8-bit Telephony Codec",
 	{1, 0, 0, 0}, /* fourcc */
 	7, /* mu-law */
-	AUDIO_CODEC_FLAG_PCM,
+	0, /* flags */
 	&MULAW_Init,
 	&MULAW_AudioOut,
 	&MULAW_CreateFrame,
@@ -195,7 +193,7 @@ AUDIO_CODEC_t Audio_Codec_PCM_MULAW = {
 	"mu-law 8-bit Telephony Codec",
 	{1, 0, 0, 0}, /* fourcc */
 	7, /* mu-law */
-	AUDIO_CODEC_FLAG_PCM,
+	0, /* flags */
 	&MULAW_Init,
 	&MULAW_AudioOut,
 	&MULAW_CreateFrame,

--- a/src/codecs/audio_pcm.c
+++ b/src/codecs/audio_pcm.c
@@ -101,7 +101,7 @@ AUDIO_CODEC_t Audio_Codec_PCM = {
 	"PCM Samples",
 	{1, 0, 0, 0}, /* fourcc */
 	1, /* format type */
-	AUDIO_CODEC_FLAG_PCM,
+	AUDIO_CODEC_FLAG_SUPPORTS_8_BIT_SAMPLES,
 	&PCM_Init,
 	&PCM_AudioOut,
 	&PCM_CreateFrame,

--- a/src/codecs/container_avi.c
+++ b/src/codecs/container_avi.c
@@ -303,7 +303,7 @@ static int AVI_Prepare(FILE *fp)
 	size_riff = 0;
 	size_movi = 0;
 	if (!AVI_WriteHeader(fp)) {
-		Log_print("Failed writing AVI header");
+		File_Export_SetErrorMessage("Failed writing AVI header");
 		return 0;
 	}
 

--- a/src/codecs/container_mp3.c
+++ b/src/codecs/container_mp3.c
@@ -23,7 +23,7 @@
 */
 
 
-/* This file is only compiled when SOUND and HAVE_LIBMP3LAME are defined. */
+/* This file is only compiled when SOUND and AUDIO_CODEC_MP3 are defined. */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,6 +40,10 @@
    */
 static int MP3_Prepare(FILE *fp)
 {
+	if (strcmp(audio_codec->codec_id, "mp3") != 0) {
+		File_Export_SetErrorMessageArg("Can't store %s in mp3 file", audio_codec->codec_id);
+		return 0;
+	}
 	return 1;
 }
 
@@ -50,6 +54,7 @@ static int MP3_AudioFrame(FILE *fp, const UBYTE *buf, int bufsize)
 
 	size = fwrite(buf, 1, bufsize, fp);
 	if (size < bufsize) {
+		File_Export_SetErrorMessage("Failed writing to MP3 file");
 		size = 0;
 	}
 
@@ -69,7 +74,6 @@ static int MP3_Finalize(FILE *fp)
 {
 	return 1;
 }
-
 
 CONTAINER_t Container_MP3 = {
 	"mp3",

--- a/src/codecs/container_wav.c
+++ b/src/codecs/container_wav.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include "file_export.h"
 #include "log.h"
+#include "file_export.h"
 #include "codecs/container.h"
 #include "codecs/container_wav.h"
 #include "codecs/audio.h"
@@ -107,6 +108,7 @@ static int WAV_Prepare(FILE *fp)
 	fputl(0, fp); /* length to be filled in upon file close */
 
 	if (ftell(fp) != 44 + audio_out->extra_data_size + fact_chunk_size) {
+		File_Export_SetErrorMessage("Error writing WAV header");
 		return 0;
 	}
 	return 1;
@@ -123,6 +125,7 @@ static int WAV_AudioFrame(FILE *fp, const UBYTE *buf, int bufsize)
 
 	size = fwrite(buf, 1, bufsize, fp);
 	if (size < bufsize) {
+		File_Export_SetErrorMessage("Failed writing to WAV file");
 		Log_print("Failed writing audio: expected %d, wrote %d", bufsize, size);
 		size = 0;
 	}

--- a/src/file_export.c
+++ b/src/file_export.c
@@ -48,6 +48,9 @@
 
 #endif /* MULTIMEDIA */
 
+#define ERROR_MSG_MAX 40
+static char error_msg[ERROR_MSG_MAX];
+char *FILE_EXPORT_error_message = error_msg;
 
 #if defined(HAVE_LIBPNG) || defined(HAVE_LIBZ)
 int FILE_EXPORT_compression_level = 6;
@@ -57,6 +60,9 @@ int FILE_EXPORT_compression_level = 6;
 
 #ifdef SOUND
 #define DEFAULT_SOUND_FILENAME_FORMAT "atari###.wav"
+#ifdef AUDIO_CODEC_MP3
+#define DEFAULT_SOUND_FILENAME_FORMAT_MP3 "atari###.mp3"
+#endif
 static char sound_filename_format[FILENAME_MAX];
 static int sound_no_last = -1;
 static int sound_no_max = 0;
@@ -203,6 +209,17 @@ void fputl(ULONG x, FILE *fp)
 	fputc((x >> 24) & 0xff, fp);
 }
 
+void File_Export_SetErrorMessage(const char *string)
+{
+	Util_strlcpy(error_msg, string, ERROR_MSG_MAX);
+}
+
+void File_Export_SetErrorMessageArg(const char *format, const char *arg)
+{
+	char msg[FILENAME_MAX + 30];
+	snprintf(msg, sizeof(msg), format, arg);
+	File_Export_SetErrorMessage(msg);
+}
 
 #ifdef MULTIMEDIA
 
@@ -253,6 +270,12 @@ int File_Export_StartRecording(const char *filename)
    RETURNS: True if filename is available, false if no filenames left in the pattern. */
 int File_Export_GetNextSoundFile(char *buffer, int bufsize) {
 	if (!sound_no_max) {
+#ifdef AUDIO_CODEC_MP3
+		if (CODECS_AUDIO_CheckType("mp3")) {
+			sound_no_max = Util_filenamepattern(DEFAULT_SOUND_FILENAME_FORMAT_MP3, sound_filename_format, FILENAME_MAX, NULL);
+		}
+		else
+#endif
 		sound_no_max = Util_filenamepattern(DEFAULT_SOUND_FILENAME_FORMAT, sound_filename_format, FILENAME_MAX, NULL);
 	}
 	return Util_findnextfilename(sound_filename_format, &sound_no_last, sound_no_max, buffer, bufsize, FALSE);

--- a/src/file_export.h
+++ b/src/file_export.h
@@ -14,6 +14,10 @@ void File_Export_WriteConfig(FILE *fp);
 void fputw(UWORD, FILE *fp);
 void fputl(ULONG, FILE *fp);
 
+extern char *FILE_EXPORT_error_message;
+void File_Export_SetErrorMessage(const char *string);
+void File_Export_SetErrorMessageArg(const char *format, const char *arg);
+
 #ifdef MULTIMEDIA
 int File_Export_IsRecording(void);
 int File_Export_StopRecording(void);

--- a/src/ui.c
+++ b/src/ui.c
@@ -1282,9 +1282,12 @@ static void SoundRecording(void)
 		char buffer[FILENAME_MAX];
 		if (File_Export_GetNextSoundFile(buffer, sizeof(buffer))) {
 			/* file does not exist - we can create it */
-			FilenameMessage(File_Export_StartRecording(buffer)
-				? "Recording sound to file \"%s\""
-				: "Can't write to file \"%s\"", buffer);
+			if (File_Export_StartRecording(buffer)) {
+				FilenameMessage("Recording sound to file \"%s\"", buffer);
+			}
+			else {
+				UI_driver->fMessage(FILE_EXPORT_error_message, 1);
+			}
 			return;
 		}
 		UI_driver->fMessage("All sound files exist!", 1);
@@ -1303,9 +1306,12 @@ static void VideoRecording(void)
 		char buffer[FILENAME_MAX];
 		if (File_Export_GetNextVideoFile(buffer, sizeof(buffer))) {
 			/* file does not exist - we can create it */
-			FilenameMessage(File_Export_StartRecording(buffer)
-				? "Recording video to file \"%s\""
-				: "Can't write to file \"%s\"", buffer);
+			if (File_Export_StartRecording(buffer)) {
+				FilenameMessage("Recording video to file \"%s\"", buffer);
+			}
+			else {
+				UI_driver->fMessage(FILE_EXPORT_error_message, 1);
+			}
 			return;
 		}
 		UI_driver->fMessage("All video files exist!", 1);


### PR DESCRIPTION
Some minor stuff: error checking and error messages related to mp3 support, better mp3 configuration, small doc edits, etc.

* added --with-mp3 config option to enable/disable mp3 support
* added on-screen error messages if something goes wrong when the user presses Alt+W or Alt+V
* added check for mp3 audio only in mp3 container
* fixed lame.h include file location check in configure.ac
* made .mp3 files be default when saving audio and -acodec mp3 selected
* fixed stats printing when no video frames produced
* added notes in README and INSTALL for mp3 audio support
* updated man page