### PR TITLE
Issue #166 - Continue emulation after playback

### DIFF
--- a/DOC/USAGE
+++ b/DOC/USAGE
@@ -206,6 +206,7 @@ Command line options
 
 -record <filename>    Record input to <filename>
 -playback <filename>  Playback input from <filename>
+-playbacknoexit       Don't exit the emulator after playback finishes
 
 -refresh <rate>       Set screen refresh rate
 -ntsc-artif none|ntsc-old|ntsc-new|ntsc-full

--- a/src/atari800.man
+++ b/src/atari800.man
@@ -665,6 +665,9 @@ Record all input events to \fIfilename\fR. Can be used for gaming contests
 .TP
 .BI \-playback\  filename
 Playback input events from \fIfilename\fR. Watch an expert play the game.
+.TP
+.B \-playbacknoexit
+Don't exit the emulator after playback finishes.
 
 .TP
 .B \-refresh

--- a/src/input.c
+++ b/src/input.c
@@ -130,6 +130,7 @@ static gzFile recordfp = NULL; /*output file for input recording*/
 static gzFile playbackfp = NULL; /*input file for playback*/
 static int recording = FALSE;
 static int playingback = FALSE;
+static int playingback_exit_after = TRUE;
 static void update_adler32_of_screen(void);
 static unsigned int compute_adler32_of_screen(void);
 static int recording_version;
@@ -236,6 +237,8 @@ int INPUT_Initialise(int *argc, char *argv[])
 				}
 			}
 			else a_m = TRUE;
+		} else if (strcmp(argv[i], "-playbacknoexit") == 0) {
+			playingback_exit_after = FALSE;
 		}
 #endif /* EVENT_RECORDING */
  		else if (strcmp(argv[i], "-directmouse") == 0) {
@@ -269,8 +272,12 @@ int INPUT_Initialise(int *argc, char *argv[])
 				Log_print("\t-directmouse     Use absolute X/Y mouse coords");
 				Log_print("\t-cx85 <n>        Emulate CX85 numeric keypad on port <n>");
 				Log_print("\t-multijoy        Emulate MultiJoy4 interface");
-				Log_print("\t-record <file>   Record input to <file>");
-				Log_print("\t-playback <file> Playback input from <file>");
+				#ifdef EVENT_RECORDING
+					Log_print("\t-record <file>   Record input to <file>");
+					Log_print("\t-playback <file> Playback input from <file>");
+					Log_print("\t-playbacknoexit  Don't exit the emulator after playback finishes");
+				#endif /* EVENT_RECORDING */
+				
 			}
 			argv[j++] = argv[i];
 		}
@@ -900,8 +907,10 @@ static void update_adler32_of_screen(void)
 	if (playingback && gzeof(playbackfp)) {
 		playingback = FALSE;
 		gzclose(playbackfp);
-		Atari800_ErrExit();
-		exit(adler32_errors > 0 ? 1 : 0); /* return code indicates errors*/
+		if (playingback_exit_after) { // exit emulation when not set otherwise
+			Atari800_ErrExit();
+			exit(adler32_errors > 0 ? 1 : 0); /* return code indicates errors*/
+		}
 	}
 }
 /* Compute the adler32 value of the visible screen */


### PR DESCRIPTION
* Added the -playbacknoexit flag to commandline parameters of src/input.c
* Added flags' description in DOC/USAGE and src/atari800.man
* Implemented flag functionality by conditionally skipping emulation exit
* Put -help records values for playback related featuren under ifdef condition to remove them when the feature is disabled in build params