### PR TITLE
Added --disable-screenshots and --disable-audiorecording

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,7 +362,7 @@ else
 	AC_CHECK_LIB(z,gzopen)
 
     dnl Need SUPPORTS_LIBPNG shell variable for PNG video codec test below
-	AC_CHECK_LIB(png,png_get_libpng_ver,[LIBS="-lpng $LIBS"; SUPPORTS_LIBPNG=yes],[SUPPORTS_LIBPNG=no])
+	AC_CHECK_LIB(png,png_get_libpng_ver,[SUPPORTS_LIBPNG=yes],[SUPPORTS_LIBPNG=no])
     if [[ "$SUPPORTS_LIBPNG" = "yes" ]]; then
         AC_DEFINE(HAVE_LIBPNG,1,[Supports PNG image compression library.])
     fi
@@ -1179,6 +1179,11 @@ if [[ "$with_video" != no -a "$WANT_CURSES_BASIC" != yes ]]; then
         supported_image_formats="pcx"
         if [[ "$SUPPORTS_LIBPNG" = "yes" ]]; then
             supported_image_formats="$supported_image_formats png"
+        fi
+    fi
+    if [[ "$WANT_SCREENSHOTS" = "yes" -o "WANT_VIDEO_RECORDING" = "yes" ]]; then
+        if [[ "$SUPPORTS_LIBPNG" = "yes" ]]; then
+            LIBS="$LIBS -lpng"
         fi
     fi
 else

--- a/configure.ac
+++ b/configure.ac
@@ -1102,42 +1102,50 @@ if [[ "$with_sound" != no ]]; then
               [Emulate the Alien Group Voice Box (default=ON)],
               VOICEBOX,[Define to emulate the Alien Group Voice Box.]
              )
+    A8_OPTION(audiorecording,"yes",
+            [Support audio recording to sound or AVI files (default=ON)],
+            AUDIO_RECORDING,[Define to enable support for audio recording to files.]
+            )
 
-    supported_audio_codecs="pcm adpcm mulaw"
-    AC_ARG_WITH(mp3,
-        [AC_HELP_STRING(--with-mp3@<:@=no|yes|lame@:>@,[Select mp3 audio @<:@default=check@:>@])],
-        [
-            case "$withval" in
-                no | yes | check | lame)
-                    ;;
-                *)
-                    AC_MSG_ERROR([unrecognized value for --with-mp3: "$withval"])
-                    ;;
-            esac
-        ],
-        [with_mp3=check])
-    if [[ "$with_mp3" != "no" ]]; then
-        if [[ "$with_mp3" = check -o "$with_mp3" = yes -o "$with_mp3" = lame ]]; then
-            AC_CHECK_LIB(mp3lame, lame_init, [
-                A8_ADD_INCLUDE_PATH([lame],[lame.h],[/usr/include /usr/local/include],[lame],[
-                    if [[ "$with_mp3" = yes -o "$with_mp3" = "lame" ]]; then
-                        AC_MSG_ERROR([lame.h not found, modify CPPFLAGS or use --with-mp3=check])
+    if [[ "$WANT_AUDIO_RECORDING" = "yes" ]]; then
+        supported_audio_codecs="pcm adpcm mulaw"
+        AC_ARG_WITH(mp3,
+            [AC_HELP_STRING(--with-mp3@<:@=no|yes|lame@:>@,[Select mp3 audio @<:@default=check@:>@])],
+            [
+                case "$withval" in
+                    no | yes | check | lame)
+                        ;;
+                    *)
+                        AC_MSG_ERROR([unrecognized value for --with-mp3: "$withval"])
+                        ;;
+                esac
+            ],
+            [with_mp3=check])
+        if [[ "$with_mp3" != "no" ]]; then
+            if [[ "$with_mp3" = check -o "$with_mp3" = yes -o "$with_mp3" = lame ]]; then
+                AC_CHECK_LIB(mp3lame, lame_init, [
+                    A8_ADD_INCLUDE_PATH([lame],[lame.h],[/usr/include /usr/local/include],[lame],[
+                        if [[ "$with_mp3" = yes -o "$with_mp3" = "lame" ]]; then
+                            AC_MSG_ERROR([lame.h not found, modify CPPFLAGS or use --with-mp3=check])
+                        fi
+                        with_mp3="no"
+                    ])
+                    if [[ $with_mp3 != no ]]; then
+                        LIBS="-lmp3lame $LIBS"
+                        AC_DEFINE(AUDIO_CODEC_MP3,1,[Supports mp3 audio])
+                        supported_audio_codecs="$supported_audio_codecs mp3"
+                        with_mp3="libmp3lame"
                     fi
-                    with_mp3=no
+                ], [
+                    if [[ "$with_mp3" = yes -o "$with_mp3" = "lame" ]]; then
+                        AC_MSG_ERROR([unable to find libmp3lame, modify LDFLAGS or use --with-mp3=check])
+                    fi
+                    with_mp3="no"
                 ])
-                if [[ $with_mp3 != no ]]; then
-                    LIBS="-lmp3lame $LIBS"
-                    AC_DEFINE(AUDIO_CODEC_MP3,1,[Supports mp3 audio])
-                    supported_audio_codecs="$supported_audio_codecs mp3"
-                    with_mp3="libmp3lame"
-                fi
-            ], [
-                if [[ "$with_mp3" = yes -o "$with_mp3" = "lame" ]]; then
-                    AC_MSG_ERROR([unable to find libmp3lame, modify LDFLAGS or use --with-mp3=check])
-                fi
-                with_mp3="no"
-            ])
+            fi
         fi
+    else
+        with_mp3="no"
     fi
 else
     WANT_NONLINEAR_MIXING="no"
@@ -1149,12 +1157,14 @@ else
     WANT_SERIO_SOUND="no"
     WANT_CLIP_SOUND="no"
     WANT_PBI_XLD_SOUND="no"
+    WANT_AUDIO_RECORDING="no"
     WANT_AUDIO_CODEC_MP3="no"
 fi
 AM_CONDITIONAL([WANT_PBI_XLD], test "$WANT_PBI_XLD" = "yes")
 AM_CONDITIONAL([WANT_VOICEBOX], test "$WANT_VOICEBOX" = "yes")
 AM_CONDITIONAL([WANT_PBI_XLD_OR_VOICEBOX], test "$WANT_PBI_XLD" = "yes" -o "$WANT_VOICEBOX" = "yes")
 AM_CONDITIONAL([WANT_PBI_MIO_OR_BB], test "$WANT_PBI_MIO" = "yes" -o "$WANT_PBI_BB" = "yes")
+AM_CONDITIONAL([WITH_AUDIO_RECORDING], test "$WANT_AUDIO_RECORDING" = "yes")
 AM_CONDITIONAL([WITH_AUDIO_CODEC_MP3], test "$with_mp3" != "no")
 
 if [[ "$with_video" != no -a "$WANT_CURSES_BASIC" != yes ]]; then
@@ -1172,10 +1182,7 @@ else
     WANT_VIDEO_RECORDING="no"
 fi
 
-if [[ "$with_sound" != no -o "$WANT_VIDEO_RECORDING" = yes ]]; then
-    AC_DEFINE(MULTIMEDIA, 1, [Define to provide multimedia recording capability.])
-fi
-AM_CONDITIONAL([WITH_MULTIMEDIA], test "$with_sound" != no -o "$WANT_VIDEO_RECORDING" = "yes")
+AM_CONDITIONAL([WITH_MULTIMEDIA], test "$WANT_AUDIO_RECORDING" = "yes" -o "$WANT_VIDEO_RECORDING" = "yes")
 
 dnl file_export.c is needed when sound is enabled (for WAV recording) or when AVI recording
 dnl is enabled, or for screenshots when screen.c is compiled into the code.
@@ -1459,9 +1466,12 @@ if [[ "$with_sound" != no ]]; then
     fi
     echo "    Using 1400XL/1450XLD emulation?...: $WANT_PBI_XLD"
     echo "    Using sound clipping?.............: $WANT_CLIP_SOUND"
-    echo "    Supported audio codecs............: $supported_audio_codecs"
-    if [[ "$with_mp3" != "no" ]]; then
-        echo "        Library for mp3 audio.........: $with_mp3"
+    echo "    Using audio recording?............: $WANT_AUDIO_RECORDING"
+    if [[ "$WANT_AUDIO_RECORDING" = "yes" ]]; then
+        echo "        Supported audio codecs........: $supported_audio_codecs"
+        if [[ "$with_mp3" != "no" ]]; then
+            echo "        Library for mp3 audio.........: $with_mp3"
+        fi
     fi
 else
     echo "    (Sound sub-options disabled)"

--- a/configure.ac
+++ b/configure.ac
@@ -370,7 +370,6 @@ else
 	AC_CHECK_LIB(m,cos,[LIBS="-lm $LIBS"])
 	AC_CHECK_LIB(ossaudio,_oss_ioctl,[LIBS="-lossaudio $LIBS"])
 fi
-AM_CONDITIONAL([WITH_LIBPNG], test "$SUPPORTS_LIBPNG" = "yes")
 
 
 dnl Set OBJS and libraries depending on host and target...
@@ -1164,29 +1163,36 @@ AM_CONDITIONAL([WANT_PBI_XLD], test "$WANT_PBI_XLD" = "yes")
 AM_CONDITIONAL([WANT_VOICEBOX], test "$WANT_VOICEBOX" = "yes")
 AM_CONDITIONAL([WANT_PBI_XLD_OR_VOICEBOX], test "$WANT_PBI_XLD" = "yes" -o "$WANT_VOICEBOX" = "yes")
 AM_CONDITIONAL([WANT_PBI_MIO_OR_BB], test "$WANT_PBI_MIO" = "yes" -o "$WANT_PBI_BB" = "yes")
-AM_CONDITIONAL([WITH_AUDIO_RECORDING], test "$WANT_AUDIO_RECORDING" = "yes")
+AM_CONDITIONAL([WITH_AUDIO_CODECS], test "$WANT_AUDIO_RECORDING" = "yes")
 AM_CONDITIONAL([WITH_AUDIO_CODEC_MP3], test "$with_mp3" != "no")
 
 if [[ "$with_video" != no -a "$WANT_CURSES_BASIC" != yes ]]; then
-    have_bitmapped_screen=yes
     A8_OPTION(videorecording,"yes",
             [Support video recording to AVI files (default=ON)],
             VIDEO_RECORDING,[Define to enable support for AVI video/audio recording.]
             )
-    supported_image_formats="pcx"
-    if [[ "$SUPPORTS_LIBPNG" = "yes" ]]; then
-        supported_image_formats="$supported_image_formats png"
+    A8_OPTION(screenshots,"yes",
+            [Support saving screenshots to files (default=ON)],
+            SCREENSHOTS,[Define to enable support for screenshot file saving.]
+            )
+    if [[ "$WANT_SCREENSHOTS" = "yes" ]]; then
+        supported_image_formats="pcx"
+        if [[ "$SUPPORTS_LIBPNG" = "yes" ]]; then
+            supported_image_formats="$supported_image_formats png"
+        fi
     fi
 else
-    have_bitmapped_screen="no"
     WANT_VIDEO_RECORDING="no"
+    WANT_SCREENSHOTS="no"
 fi
 
 AM_CONDITIONAL([WITH_MULTIMEDIA], test "$WANT_AUDIO_RECORDING" = "yes" -o "$WANT_VIDEO_RECORDING" = "yes")
+AM_CONDITIONAL([WITH_IMAGE_CODECS], test "$WANT_SCREENSHOTS" = "yes" -o "$WANT_VIDEO_RECORDING" = "yes")
+AM_CONDITIONAL([WITH_IMAGE_CODEC_PNG], test "$SUPPORTS_LIBPNG" = "yes")
 
 dnl file_export.c is needed when sound is enabled (for WAV recording) or when AVI recording
 dnl is enabled, or for screenshots when screen.c is compiled into the code.
-AM_CONDITIONAL([WITH_FILE_EXPORT], test "$with_sound" != no -o "$have_bitmapped_screen" = "yes")
+AM_CONDITIONAL([WITH_FILE_EXPORT], test "$WANT_AUDIO_RECORDING" = "yes" -o "$WANT_VIDEO_RECORDING" = "yes" -o "$WANT_SCREENSHOTS" = "yes")
 
 dnl Set video recording configuration options
 
@@ -1212,7 +1218,7 @@ if [[ "$WANT_VIDEO_RECORDING" = "yes" ]]; then
     fi
 fi
 
-AM_CONDITIONAL([WITH_VIDEO_RECORDING], test "$WANT_VIDEO_RECORDING" = "yes")
+AM_CONDITIONAL([WITH_VIDEO_CODECS], test "$WANT_VIDEO_RECORDING" = "yes")
 AM_CONDITIONAL([WITH_VIDEO_CODEC_PNG], test "$WANT_VIDEO_RECORDING" = "yes" -a "$WANT_VIDEO_CODEC_PNG" = "yes")
 AM_CONDITIONAL([WITH_VIDEO_CODEC_ZMBV], test "$WANT_VIDEO_RECORDING" = "yes" -a "$WANT_VIDEO_CODEC_ZMBV" = "yes")
 
@@ -1426,8 +1432,11 @@ if [[ "$a8_target" = default ]]; then
     esac
 fi
 if [[ "$a8_target" != "default" -o "$with_video" != no ]]; then
+    echo "Using screenshots?....................: $WANT_SCREENSHOTS"
+    if [[ "$WANT_SCREENSHOTS" = "yes" ]]; then
+        echo "    Supported screenshot formats......: $supported_image_formats"
+    fi
     if [[ "$WANT_CURSES_BASIC" != "yes" ]]; then
-        echo "Supported screenshot formats..........: $supported_image_formats"
         echo "Using cycle exact?....................: $WANT_NEW_CYCLE_EXACT"
         echo "Using the very slow computer support?.: $WANT_VERY_SLOW"
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -354,12 +354,19 @@ if [[ "$a8_target" = "android" ]]; then
     echo "hardcoding libz"
     LIBS="-lz $LIBS"
     AC_DEFINE(HAVE_LIBZ)
+    SUPPORTS_LIBZ="yes"
     dnl libm is automatically appended by the build system
 elif [[ "$a8_target" = "libatari800" ]]; then
     AC_CHECK_LIB(m,cos,[LIBS="-lm $LIBS"])
     AC_CHECK_FUNCS(setjmp)
+    SUPPORTS_LIBZ="no"
 else
-	AC_CHECK_LIB(z,gzopen)
+    dnl needs SUPPORTS_LIBZ shell variable for file_export test below
+	AC_CHECK_LIB(z,gzopen,[SUPPORTS_LIBZ=yes],[SUPPORTS_LIBZ=no])
+    if [[ "$SUPPORTS_LIBZ" = "yes" ]]; then
+        AC_DEFINE(HAVE_LIBZ,1,[Supports zlib compression library.])
+        LIBS="-lz $LIBS"
+    fi
 
     dnl Need SUPPORTS_LIBPNG shell variable for PNG video codec test below
 	AC_CHECK_LIB(png,png_get_libpng_ver,[SUPPORTS_LIBPNG=yes],[SUPPORTS_LIBPNG=no])
@@ -1197,7 +1204,7 @@ AM_CONDITIONAL([WITH_IMAGE_CODEC_PNG], test "$SUPPORTS_LIBPNG" = "yes")
 
 dnl file_export.c is needed when sound is enabled (for WAV recording) or when AVI recording
 dnl is enabled, or for screenshots when screen.c is compiled into the code.
-AM_CONDITIONAL([WITH_FILE_EXPORT], test "$WANT_AUDIO_RECORDING" = "yes" -o "$WANT_VIDEO_RECORDING" = "yes" -o "$WANT_SCREENSHOTS" = "yes")
+AM_CONDITIONAL([WITH_FILE_EXPORT], test "$WANT_AUDIO_RECORDING" = "yes" -o "$WANT_VIDEO_RECORDING" = "yes" -o "$WANT_SCREENSHOTS" = "yes" -o "$SUPPORTS_LIBZ" = "yes")
 
 dnl Set video recording configuration options
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,7 +128,7 @@ if WITH_FILE_EXPORT
 atari800_SOURCES += file_export.c file_export.h
 if WITH_MULTIMEDIA
 atari800_SOURCES += codecs/container.c codecs/container.h
-if WITH_SOUND
+if WITH_AUDIO_RECORDING
 atari800_SOURCES += codecs/container_wav.c codecs/container_wav.h \
 	codecs/audio.c codecs/audio.h \
 	codecs/audio_pcm.c codecs/audio_pcm.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -124,11 +124,18 @@ endif
 if WANT_POKEYREC
 atari800_SOURCES += pokeyrec.c pokeyrec.h
 endif
+if WITH_IMAGE_CODECS
+atari800_SOURCES += codecs/image.c codecs/image.h \
+	codecs/image_pcx.c codecs/image_pcx.h
+if WITH_IMAGE_CODEC_PNG
+atari800_SOURCES += codecs/image_png.c codecs/image_png.h
+endif
+endif
 if WITH_FILE_EXPORT
 atari800_SOURCES += file_export.c file_export.h
 if WITH_MULTIMEDIA
 atari800_SOURCES += codecs/container.c codecs/container.h
-if WITH_AUDIO_RECORDING
+if WITH_AUDIO_CODECS
 atari800_SOURCES += codecs/container_wav.c codecs/container_wav.h \
 	codecs/audio.c codecs/audio.h \
 	codecs/audio_pcm.c codecs/audio_pcm.h \
@@ -139,7 +146,7 @@ atari800_SOURCES += codecs/audio_mp3.c codecs/audio_mp3.h \
 	codecs/container_mp3.c codecs/container_mp3.h
 endif
 endif
-if WITH_VIDEO_RECORDING
+if WITH_VIDEO_CODECS
 atari800_SOURCES += codecs/container_avi.c codecs/container_avi.h \
 	codecs/video.c codecs/video.h \
 	codecs/video_mrle.c codecs/video_mrle.h
@@ -229,12 +236,7 @@ atari800_SOURCES += \
 	colours_ntsc.c colours_ntsc.h \
 	colours_pal.c colours_pal.h \
 	colours_external.c colours_external.h \
-	screen.c screen.h \
-	codecs/image.c codecs/image.h \
-	codecs/image_pcx.c codecs/image_pcx.h
-if WITH_LIBPNG
-atari800_SOURCES += codecs/image_png.c codecs/image_png.h
-endif
+	screen.c screen.h
 if WANT_NEW_CYCLE_EXACT
 atari800_SOURCES += cycle_map.c cycle_map.h
 endif

--- a/src/atari.c
+++ b/src/atari.c
@@ -90,7 +90,7 @@
 #include "colours.h"
 #include "screen.h"
 #endif
-#if !defined(DREAMCAST) && defined(MULTIMEDIA)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 #include "file_export.h"
 #endif
 #ifndef BASIC
@@ -809,7 +809,7 @@ int Atari800_Initialise(int *argc, char *argv[])
 #if !defined(BASIC) && !defined(CURSES_BASIC)
 		|| !Screen_Initialise(argc, argv)
 		|| !UI_Initialise(argc, argv)
-#if !defined(DREAMCAST) && defined(MULTIMEDIA)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 		|| !File_Export_Initialise(argc, argv)
 #endif
 #endif
@@ -1040,7 +1040,7 @@ int Atari800_Exit(int run_monitor)
 #ifdef R_IO_DEVICE
 		RDevice_Exit(); /* R: Device cleanup */
 #endif
-#if !defined(DREAMCAST) && defined(MULTIMEDIA)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 		File_Export_StopRecording();
 #endif
 		MONITOR_Exit();
@@ -1374,7 +1374,7 @@ void Atari800_Frame(void)
 #ifdef SOUND
 	Sound_Update();
 #endif
-#if defined(MULTIMEDIA) && (!defined(BASIC) && !defined(CURSES_BASIC))
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 	/* multimedia stats are drawn here so they don't get recorded in the video */
 	Screen_DrawMultimediaStats();
 #endif

--- a/src/atari.c
+++ b/src/atari.c
@@ -1305,7 +1305,7 @@ void Atari800_Frame(void)
 		Sound_Continue();
 #endif
 		break;
-#ifndef CURSES_BASIC
+#ifdef SCREENSHOTS
 	case AKEY_SCREENSHOT:
 		Screen_SaveNextScreenshot(FALSE);
 		break;

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -483,7 +483,7 @@ int CFG_WriteConfig(void)
 #if defined(SOUND) && defined(SOUND_THIN_API)
 	Sound_WriteConfig(fp);
 #endif /* defined(SOUND) && defined(SOUND_THIN_API) */
-#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
+#if defined(HAVE_LIBPNG) || defined(HAVE_LIBZ) || defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 	File_Export_WriteConfig(fp);
 #endif
 #ifdef SUPPORTS_PLATFORM_CONFIGSAVE

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -483,7 +483,7 @@ int CFG_WriteConfig(void)
 #if defined(SOUND) && defined(SOUND_THIN_API)
 	Sound_WriteConfig(fp);
 #endif /* defined(SOUND) && defined(SOUND_THIN_API) */
-#if (defined(SOUND) && !defined(DREAMCAST)) || defined(VIDEO_RECORDING)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 	File_Export_WriteConfig(fp);
 #endif
 #ifdef SUPPORTS_PLATFORM_CONFIGSAVE

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -62,7 +62,7 @@
 #ifdef SOUND
 #include "sound.h"
 #endif
-#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
+#if defined(HAVE_LIBPNG) || defined(HAVE_LIBZ) || defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 #include "file_export.h"
 #endif
 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -62,7 +62,7 @@
 #ifdef SOUND
 #include "sound.h"
 #endif
-#if (defined(SOUND) && !defined(DREAMCAST)) || defined(VIDEO_RECORDING)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 #include "file_export.h"
 #endif
 
@@ -338,7 +338,7 @@ int CFG_LoadConfig(const char *alternate_config_filename)
 			else if (Sound_ReadConfig(string, ptr)) {
 			}
 #endif /* defined(SOUND) && defined(SOUND_THIN_API) */
-#if (defined(SOUND) && !defined(DREAMCAST)) || defined(VIDEO_RECORDING)
+#if defined(HAVE_LIBPNG) || defined(HAVE_LIBZ) || defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 			else if (File_Export_ReadConfig(string, ptr)) {
 			}
 #endif

--- a/src/codecs/audio.c
+++ b/src/codecs/audio.c
@@ -22,8 +22,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-/* This file is only included in compilation when sound enabled, so no need to
-   do any #ifdef SOUND directives. */
+/* This file is only included in compilation when audio recording enabled,
+   so no need to do any #ifdef AUDIO_RECORDING directives. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/codecs/container.c
+++ b/src/codecs/container.c
@@ -23,7 +23,7 @@
 */
 
 
-/* This file is only compiled when either SOUND or VIDEO_RECORDING is defined. */
+/* This file is compiled when AUDIO_RECORDING or VIDEO_RECORDING is defined. */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,7 +32,7 @@
 #include "log.h"
 #include "file_export.h"
 #include "codecs/container.h"
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 #include "sound.h"
 #include "codecs/audio.h"
 #include "codecs/container_wav.h"
@@ -70,7 +70,7 @@ float fps;
 char description[32];
 
 static CONTAINER_t *known_containers[] = {
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	&Container_WAV,
 #ifdef AUDIO_CODEC_MP3
 	&Container_MP3,
@@ -135,7 +135,7 @@ static int close_codecs(void)
 		video_codec = NULL;
 	}
 #endif
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	if (audio_codec) {
 		CODECS_AUDIO_End();
 		audio_codec = NULL;
@@ -175,7 +175,7 @@ int CONTAINER_Open(const char *filename)
 		smallest_audio_frame = 0xffffffff;
 		largest_audio_frame = 0;
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 		if (Sound_enabled) {
 			if (!CODECS_AUDIO_Init()) {
 				/* error message set in codec */
@@ -206,7 +206,7 @@ int CONTAINER_Open(const char *filename)
 			strcat(description, video_codec->codec_id);
 		}
 #endif
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 		if (audio_codec) {
 			/* If the audio codec has the same name as the container (e.g. mp3
 			   is both a codec and container type), don't duplicate the name */
@@ -241,7 +241,7 @@ int CONTAINER_Open(const char *filename)
 	return (fp != NULL);
 }
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 int CONTAINER_AddAudioSamples(const UBYTE *buf, int num_samples)
 {
 	int result;
@@ -382,7 +382,7 @@ int CONTAINER_Close(int file_ok)
 	/* Note that all video frames will be written, but the audio codec may
 		still have frames buffered. */
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	if (file_ok && audio_codec && audio_codec->flush((float)(video_frame_count / fps))) {
 		/* Force audio codec to write out any remaining frames. This only
 			occurs in codecs that buffer frames or force fixed block sizes */

--- a/src/codecs/container.h
+++ b/src/codecs/container.h
@@ -45,7 +45,7 @@ extern CONTAINER_t *container;
 
 int CONTAINER_IsSupported(const char *filename);
 int CONTAINER_Open(const char *filename);
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 int CONTAINER_AddAudioSamples(const UBYTE *buf, int num_samples);
 #endif
 #ifdef VIDEO_RECORDING

--- a/src/codecs/container_avi.c
+++ b/src/codecs/container_avi.c
@@ -30,7 +30,7 @@
 #include "colours.h"
 #include "util.h"
 #include "log.h"
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 #include "codecs/audio.h"
 #endif
 #include "codecs/image.h"
@@ -109,7 +109,7 @@ static int AVI_WriteHeader(FILE *fp) {
 	   header which is (strl header LIST + (strh + strf + strn)) */
 	list_size = 4 + 8 + 56 + (12 + (8 + 56 + 8 + 40 + 256*4 + 8 + 16));
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	/* if audio is included, add size of audio stream strl header LIST + (strh + strf + strn) */
 	if (num_streams == 2) list_size += 12 + (8 + 56 + 8 + 18 + audio_out->extra_data_size + 8 + 12);
 #endif
@@ -208,7 +208,7 @@ static int AVI_WriteHeader(FILE *fp) {
 	fputc(0, fp); /* null terminator */
 	fputc(0, fp); /* padding to get to 16 bytes */
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	if (num_streams == 2) {
 		/* audio stream format */
 
@@ -265,7 +265,7 @@ static int AVI_WriteHeader(FILE *fp) {
 		fputs("POKEY audio", fp);
 		fputc(0, fp); /* null terminator */
 	}
-#endif /* SOUND */
+#endif /* AUDIO_RECORDING */
 
 	/* audia/video data */
 
@@ -289,7 +289,7 @@ static int AVI_WriteHeader(FILE *fp) {
    */
 static int AVI_Prepare(FILE *fp)
 {
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	if (audio_codec) {
 		num_streams = 2;
 	}
@@ -369,7 +369,7 @@ static int AVI_VideoFrame(FILE *fp, const UBYTE *buf, int bufsize, int is_keyfra
 	return AVI_WriteFrame(fp, buf, bufsize, VIDEO_FRAME_FLAG, is_keyframe);
 }
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 /* AVI_AudioFrame adds audio data to the stream and update the audio
    statistics. */
 static int AVI_AudioFrame(FILE *fp, const UBYTE *buf, int bufsize) {
@@ -457,7 +457,7 @@ CONTAINER_t Container_AVI = {
 	"avi",
 	"AVI format multimedia",
 	&AVI_Prepare,
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	&AVI_AudioFrame,
 #else
 	NULL,

--- a/src/codecs/container_mp3.c
+++ b/src/codecs/container_mp3.c
@@ -23,7 +23,7 @@
 */
 
 
-/* This file is only compiled when SOUND and AUDIO_CODEC_MP3 are defined. */
+/* This file is only compiled when AUDIO_RECORDING and AUDIO_CODEC_MP3 are defined. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/codecs/container_wav.c
+++ b/src/codecs/container_wav.c
@@ -23,7 +23,7 @@
 */
 
 
-/* This file is only compiled when SOUND is defined. */
+/* This file is only compiled when AUDIO_RECORDING is defined. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/codecs/image_png.c
+++ b/src/codecs/image_png.c
@@ -150,7 +150,7 @@ static int PNG_SaveScreen(FILE *fp, UBYTE *ptr1, UBYTE *ptr2)
 #ifdef VIDEO_CODEC_PNG
 	return current_png_size;
 #else
-	return 0;
+	return -1;
 #endif
 }
 

--- a/src/file_export.c
+++ b/src/file_export.c
@@ -35,10 +35,10 @@
 #include "codecs/image.h"
 #endif
 
-#ifdef MULTIMEDIA
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 #include "codecs/container.h"
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 #include "codecs/audio.h"
 #endif
 
@@ -46,7 +46,7 @@
 #include "codecs/video.h"
 #endif
 
-#endif /* MULTIMEDIA */
+#endif /* defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
 #define ERROR_MSG_MAX 40
 static char error_msg[ERROR_MSG_MAX];
@@ -56,9 +56,9 @@ char *FILE_EXPORT_error_message = error_msg;
 int FILE_EXPORT_compression_level = 6;
 #endif
 
-#ifdef MULTIMEDIA
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 #define DEFAULT_SOUND_FILENAME_FORMAT "atari###.wav"
 #ifdef AUDIO_CODEC_MP3
 #define DEFAULT_SOUND_FILENAME_FORMAT_MP3 "atari###.mp3"
@@ -66,7 +66,7 @@ int FILE_EXPORT_compression_level = 6;
 static char sound_filename_format[FILENAME_MAX];
 static int sound_no_last = -1;
 static int sound_no_max = 0;
-#endif /* SOUND */
+#endif /* AUDIO_RECORDING */
 
 #ifdef VIDEO_RECORDING
 #define DEFAULT_VIDEO_FILENAME_FORMAT "atari###.avi"
@@ -75,12 +75,12 @@ static int video_no_last = -1;
 static int video_no_max = 0;
 #endif /* VIDEO_RECORDING */
 
-#endif /* MULTIMEDIA */
+#endif /* defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
 
 int File_Export_Initialise(int *argc, char *argv[])
 {
-#if defined(HAVE_LIBPNG) || defined(HAVE_LIBZ) || defined(MULTIMEDIA)
+#if defined(HAVE_LIBPNG) || defined(HAVE_LIBZ) || defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 	int i;
 	int j;
 
@@ -102,7 +102,7 @@ int File_Export_Initialise(int *argc, char *argv[])
 			else a_m = TRUE;
 		}
 #endif
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 		else if (strcmp(argv[i], "-aname") == 0) {
 			if (i_a)
 				sound_no_max = Util_filenamepattern(argv[++i], sound_filename_format, FILENAME_MAX, DEFAULT_SOUND_FILENAME_FORMAT);
@@ -122,7 +122,7 @@ int File_Export_Initialise(int *argc, char *argv[])
 				Log_print("\t-compression-level <n>");
 				Log_print("\t                 Set zlib/PNG compression level 0-9 (default 6)");
 #endif
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 				Log_print("\t-aname <p>       Set filename pattern for audio recording");
 #endif
 #ifdef VIDEO_RECORDING
@@ -141,10 +141,10 @@ int File_Export_Initialise(int *argc, char *argv[])
 		}
 	}
 	*argc = j;
-#endif /* defined(HAVE_LIBPNG) || defined(HAVE_LIBZ) || defined(MULTIMEDIA) */
+#endif /* defined(HAVE_LIBPNG) || defined(HAVE_LIBZ) || defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
 	return TRUE
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 		&& CODECS_AUDIO_Initialise(argc, argv)
 #endif
 #ifdef VIDEO_RECORDING
@@ -168,7 +168,7 @@ int File_Export_ReadConfig(char *string, char *ptr)
 	else if (CODECS_VIDEO_ReadConfig(string, ptr)) {
 	}
 #endif
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	else if (CODECS_AUDIO_ReadConfig(string, ptr)) {
 	}
 #endif
@@ -184,7 +184,7 @@ void File_Export_WriteConfig(FILE *fp)
 #ifdef VIDEO_RECORDING
 	CODECS_VIDEO_WriteConfig(fp);
 #endif
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 	CODECS_AUDIO_WriteConfig(fp);
 #endif
 }
@@ -221,7 +221,7 @@ void File_Export_SetErrorMessageArg(const char *format, const char *arg)
 	File_Export_SetErrorMessage(msg);
 }
 
-#ifdef MULTIMEDIA
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 
 /* File_Export_IsRecording simply returns true if any multimedia file is
    currently open and able to receive writes.
@@ -265,7 +265,7 @@ int File_Export_StartRecording(const char *filename)
 	return CONTAINER_Open(filename);
 }
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 /* Get the next filename in the sound_file_format pattern.
    RETURNS: True if filename is available, false if no filenames left in the pattern. */
 int File_Export_GetNextSoundFile(char *buffer, int bufsize) {
@@ -302,7 +302,7 @@ int File_Export_WriteAudio(const UBYTE *samples, int num_samples)
 
 	return result;
 }
-#endif /* SOUND */
+#endif /* AUDIO_RECORDING */
 
 #ifdef VIDEO_RECORDING
 /* Get the next filename in the video_file_format pattern.
@@ -354,7 +354,7 @@ int File_Export_GetRecordingStats(int *seconds, int *size, char **media_type)
 	return 0;
 }
 
-#endif /* MULTIMEDIA */
+#endif /* defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
 #if !defined(BASIC) && !defined(CURSES_BASIC)
 

--- a/src/file_export.c
+++ b/src/file_export.c
@@ -31,7 +31,7 @@
 #include "util.h"
 #include "log.h"
 
-#if !defined(BASIC) && !defined(CURSES_BASIC)
+#ifdef SCREENSHOTS
 #include "codecs/image.h"
 #endif
 
@@ -356,7 +356,7 @@ int File_Export_GetRecordingStats(int *seconds, int *size, char **media_type)
 
 #endif /* defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
-#if !defined(BASIC) && !defined(CURSES_BASIC)
+#ifdef SCREENSHOTS
 
 /* Convenience function to check whether the specifed image type is supported.
 
@@ -387,4 +387,4 @@ int File_Export_SaveScreen(const char *filename, UBYTE *ptr1, UBYTE *ptr2) {
 	return result;
 }
 
-#endif /* !defined(BASIC) && !defined(CURSES_BASIC) */
+#endif /*def SCREENSHOTS */

--- a/src/file_export.c
+++ b/src/file_export.c
@@ -189,7 +189,7 @@ void File_Export_WriteConfig(FILE *fp)
 #endif
 }
 
-
+#if defined(SCREENSHOTS) || defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 /* fputw and fputl are utility functions to write values as little-endian format
    regardless of the endianness of the platform. */
 
@@ -208,6 +208,9 @@ void fputl(ULONG x, FILE *fp)
 	fputc((x >> 16) & 0xff, fp);
 	fputc((x >> 24) & 0xff, fp);
 }
+#endif
+
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 
 void File_Export_SetErrorMessage(const char *string)
 {
@@ -220,8 +223,6 @@ void File_Export_SetErrorMessageArg(const char *format, const char *arg)
 	snprintf(msg, sizeof(msg), format, arg);
 	File_Export_SetErrorMessage(msg);
 }
-
-#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 
 /* File_Export_IsRecording simply returns true if any multimedia file is
    currently open and able to receive writes.

--- a/src/file_export.h
+++ b/src/file_export.h
@@ -36,7 +36,7 @@ int File_Export_WriteVideo(void);
 int File_Export_GetRecordingStats(int *seconds, int *size, char **media_type);
 #endif /* defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
-#if !defined(BASIC) && !defined(CURSES_BASIC)
+#ifdef SCREENSHOTS
 int File_Export_ImageTypeSupported(const char *id);
 int File_Export_SaveScreen(const char *filename, UBYTE *ptr1, UBYTE *ptr2);
 #endif

--- a/src/file_export.h
+++ b/src/file_export.h
@@ -11,14 +11,16 @@ int File_Export_Initialise(int *argc, char *argv[]);
 int File_Export_ReadConfig(char *string, char *ptr);
 void File_Export_WriteConfig(FILE *fp);
 
+#if defined(SCREENSHOTS) || defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 void fputw(UWORD, FILE *fp);
 void fputl(ULONG, FILE *fp);
+#endif
 
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 extern char *FILE_EXPORT_error_message;
 void File_Export_SetErrorMessage(const char *string);
 void File_Export_SetErrorMessageArg(const char *format, const char *arg);
 
-#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 int File_Export_IsRecording(void);
 int File_Export_StopRecording(void);
 int File_Export_StartRecording(const char *fileName);

--- a/src/file_export.h
+++ b/src/file_export.h
@@ -18,12 +18,12 @@ extern char *FILE_EXPORT_error_message;
 void File_Export_SetErrorMessage(const char *string);
 void File_Export_SetErrorMessageArg(const char *format, const char *arg);
 
-#ifdef MULTIMEDIA
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 int File_Export_IsRecording(void);
 int File_Export_StopRecording(void);
 int File_Export_StartRecording(const char *fileName);
 
-#ifdef SOUND
+#ifdef AUDIO_RECORDING
 int File_Export_GetNextSoundFile(char *buffer, int bufsize);
 int File_Export_WriteAudio(const UBYTE *samples, int num_samples);
 #endif
@@ -34,7 +34,7 @@ int File_Export_WriteVideo(void);
 #endif
 
 int File_Export_GetRecordingStats(int *seconds, int *size, char **media_type);
-#endif /* MULTIMEDIA */
+#endif /* defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
 #if !defined(BASIC) && !defined(CURSES_BASIC)
 int File_Export_ImageTypeSupported(const char *id);

--- a/src/pokeysnd.c
+++ b/src/pokeysnd.c
@@ -30,9 +30,10 @@
 #include "asap_internal.h"
 #else
 #include "atari.h"
-#ifndef __PLUS
+#ifdef AUDIO_RECORDING
 #include "file_export.h"
-#else
+#endif
+#ifdef __PLUS
 #include "sound_win.h"
 #endif
 #endif
@@ -295,7 +296,9 @@ static void init_vol_only(void)
 
 int POKEYSND_DoInit(void)
 {
+#ifdef AUDIO_RECORDING
 	File_Export_StopRecording();
+#endif
 
 #ifdef VOL_ONLY_SOUND
 	init_vol_only();
@@ -361,7 +364,7 @@ void POKEYSND_Process(void *sndbuffer, int sndn)
 #if defined(PBI_XLD) || defined (VOICEBOX)
 	VOTRAXSND_Process(sndbuffer,sndn);
 #endif
-#if !defined(__PLUS) && !defined(ASAP)
+#if defined(AUDIO_RECORDING)
 	File_Export_WriteAudio((const unsigned char *)sndbuffer, sndn);
 #endif
 }
@@ -383,7 +386,7 @@ int POKEYSND_UpdateProcessBuffer(void)
 #if defined(PBI_XLD) || defined (VOICEBOX)
 	VOTRAXSND_Process(POKEYSND_process_buffer, sndn);
 #endif
-#if !defined(__PLUS) && !defined(ASAP)
+#if defined(AUDIO_RECORDING)
 	File_Export_WriteAudio((const unsigned char *)POKEYSND_process_buffer, sndn);
 #endif
 	return sndn;

--- a/src/screen.c
+++ b/src/screen.c
@@ -80,7 +80,7 @@ static char screenshot_filename_format[FILENAME_MAX];
 static int screenshot_no_last = -1;
 static int screenshot_no_max = 0;
 
-#if defined(SOUND) || defined(VIDEO_RECORDING)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 int Screen_show_multimedia_stats = TRUE;
 #endif
 #endif /* !DREAMCAST */
@@ -101,7 +101,7 @@ int Screen_Initialise(int *argc, char *argv[])
 				screenshot_no_max = Util_filenamepattern(argv[++i], screenshot_filename_format, FILENAME_MAX, DEFAULT_SCREENSHOT_FILENAME_FORMAT);
 			else a_m = TRUE;
 		}
-#if defined(SOUND) || defined(VIDEO_RECORDING)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 		else if (strcmp(argv[i], "-showstats") == 0) {
 			Screen_show_multimedia_stats = TRUE;
 		}
@@ -119,7 +119,7 @@ int Screen_Initialise(int *argc, char *argv[])
 				help_only = TRUE;
 #ifndef DREAMCAST
 				Log_print("\t-screenshots <p> Set filename pattern for screenshots");
-#if defined(SOUND) || defined(VIDEO_RECORDING)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 				Log_print("\t-showstats       Show recording stats of video or audio");
 				Log_print("\t-no-showstats    Don't show recording stats of video or audio");
 #endif
@@ -169,7 +169,7 @@ int Screen_ReadConfig(char *string, char *ptr)
 		return (Screen_show_sector_counter = Util_sscanbool(ptr)) != -1;
 	else if (strcmp(string, "SCREEN_SHOW_1200XL_LEDS") == 0)
 		return (Screen_show_1200_leds = Util_sscanbool(ptr)) != -1;
-#if !defined(DREAMCAST) && (defined(SOUND) || defined(VIDEO_RECORDING))
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 	else if (strcmp(string, "SCREEN_SHOW_MULTIMEDIA_STATS") == 0)
 		return (Screen_show_multimedia_stats = Util_sscanbool(ptr)) != -1;
 #endif
@@ -183,7 +183,7 @@ void Screen_WriteConfig(FILE *fp)
 	fprintf(fp, "SCREEN_SHOW_IO_ACTIVITY=%d\n", Screen_show_disk_led);
 	fprintf(fp, "SCREEN_SHOW_IO_COUNTER=%d\n", Screen_show_sector_counter);
 	fprintf(fp, "SCREEN_SHOW_1200XL_LEDS=%d\n", Screen_show_1200_leds);
-#if !defined(DREAMCAST) && (defined(SOUND) || defined(VIDEO_RECORDING))
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 	fprintf(fp, "SCREEN_SHOW_MULTIMEDIA_STATS=%d\n", Screen_show_multimedia_stats);
 #endif
 }
@@ -718,7 +718,7 @@ void Screen_Draw1200LED(void)
 }
 
 #ifndef DREAMCAST
-#if defined(SOUND) || defined(VIDEO_RECORDING)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 /* Returns screen address for placing the next character on the left of the
    drawn number. */
 static UBYTE *SmallFont_DrawFloat(UBYTE *screen, float f, int num_decimal_places, UBYTE color1, UBYTE color2)
@@ -845,7 +845,7 @@ void Screen_DrawMultimediaStats(void)
 		}
 	}
 }
-#endif /* defined(SOUND) || defined(VIDEO_RECORDING) */
+#endif /* defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
 int Screen_SaveScreenshot(const char *filename, int interlaced)
 {

--- a/src/screen.c
+++ b/src/screen.c
@@ -38,7 +38,7 @@
 #include "screen.h"
 #include "sio.h"
 #include "util.h"
-#ifndef DREAMCAST
+#if defined(SCREENSHOTS) || defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 #include "file_export.h"
 #endif
 
@@ -69,7 +69,7 @@ int Screen_show_disk_led = TRUE;
 int Screen_show_sector_counter = FALSE;
 int Screen_show_1200_leds = TRUE;
 
-#ifndef DREAMCAST
+#ifdef SCREENSHOTS
 #ifdef HAVE_LIBPNG
 #define DEFAULT_SCREENSHOT_FILENAME_FORMAT "atari###.png"
 #else
@@ -79,11 +79,11 @@ int Screen_show_1200_leds = TRUE;
 static char screenshot_filename_format[FILENAME_MAX];
 static int screenshot_no_last = -1;
 static int screenshot_no_max = 0;
+#endif /* !SCREENSHOTS */
 
 #if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 int Screen_show_multimedia_stats = TRUE;
 #endif
-#endif /* !DREAMCAST */
 
 int Screen_Initialise(int *argc, char *argv[])
 {
@@ -92,15 +92,19 @@ int Screen_Initialise(int *argc, char *argv[])
 	int help_only = FALSE;
 
 	for (i = j = 1; i < *argc; i++) {
+#ifdef SCREENSHOTS
 		int i_a = (i + 1 < *argc);		/* is argument available? */
 		int a_m = FALSE;			/* error, argument missing! */
+#endif
 
-#ifndef DREAMCAST
-		if (strcmp(argv[i], "-screenshots") == 0) {
+		if (0) {}
+#ifdef SCREENSHOTS
+		else if (strcmp(argv[i], "-screenshots") == 0) {
 			if (i_a)
 				screenshot_no_max = Util_filenamepattern(argv[++i], screenshot_filename_format, FILENAME_MAX, DEFAULT_SCREENSHOT_FILENAME_FORMAT);
 			else a_m = TRUE;
 		}
+#endif
 #if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 		else if (strcmp(argv[i], "-showstats") == 0) {
 			Screen_show_multimedia_stats = TRUE;
@@ -109,30 +113,30 @@ int Screen_Initialise(int *argc, char *argv[])
 			Screen_show_multimedia_stats = FALSE;
 		}
 #endif
-		else
-#endif /* !DREAMCAST */
-		if (strcmp(argv[i], "-showspeed") == 0) {
+		else if (strcmp(argv[i], "-showspeed") == 0) {
 			Screen_show_atari_speed = TRUE;
 		}
 		else {
 			if (strcmp(argv[i], "-help") == 0) {
 				help_only = TRUE;
-#ifndef DREAMCAST
+#ifdef SCREENSHOTS
 				Log_print("\t-screenshots <p> Set filename pattern for screenshots");
+#endif
 #if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 				Log_print("\t-showstats       Show recording stats of video or audio");
 				Log_print("\t-no-showstats    Don't show recording stats of video or audio");
 #endif
-#endif /* !DREAMCAST */
 				Log_print("\t-showspeed       Show percentage of actual speed");
 			}
 			argv[j++] = argv[i];
 		}
 
+#ifdef SCREENSHOTS
 		if (a_m) {
 			Log_print("Missing argument for '%s'", argv[i]);
 			return FALSE;
 		}
+#endif
 	}
 	*argc = j;
 
@@ -717,7 +721,6 @@ void Screen_Draw1200LED(void)
 	}
 }
 
-#ifndef DREAMCAST
 #if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 /* Returns screen address for placing the next character on the left of the
    drawn number. */
@@ -847,6 +850,7 @@ void Screen_DrawMultimediaStats(void)
 }
 #endif /* defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING) */
 
+#ifdef SCREENSHOTS
 int Screen_SaveScreenshot(const char *filename, int interlaced)
 {
 	int result;
@@ -888,7 +892,7 @@ void Screen_SaveNextScreenshot(int interlaced)
 	Util_findnextfilename(screenshot_filename_format, &screenshot_no_last, screenshot_no_max, filename, sizeof(filename), TRUE);
 	Screen_SaveScreenshot(filename, interlaced);
 }
-#endif /* !DREAMCAST */
+#endif /* !SCREENSHOTS */
 
 void Screen_EntireDirty(void)
 {

--- a/src/ui.c
+++ b/src/ui.c
@@ -4109,7 +4109,7 @@ static int SoundSettings(void)
 
 #endif /* SOUND */
 
-#if !defined(CURSES_BASIC) && !defined(DREAMCAST)
+#ifdef SCREENSHOTS
 
 static void Screenshot(int interlaced)
 {
@@ -4168,7 +4168,9 @@ static void FunctionKeyHelp(void)
 		"F8  - Enter monitor        \0"
 		"      (-console required)  \0"
 		"F9  - Exit emulator        \0"
+#ifdef SCREENSHOTS
 		"F10 - Save screenshot      \0"
+#endif
 		"\n");
 }
 
@@ -4271,7 +4273,7 @@ void UI_Run(void)
 		UI_MENU_SUBMENU(UI_MENU_SETTINGS, "Emulator Configuration"),
 		UI_MENU_FILESEL_ACCEL(UI_MENU_SAVESTATE, "Save State", "Alt+S"),
 		UI_MENU_FILESEL_ACCEL(UI_MENU_LOADSTATE, "Load State", "Alt+L"),
-#if !defined(CURSES_BASIC) && !defined(DREAMCAST)
+#if SCREENSHOTS
 #ifdef HAVE_LIBPNG
 		UI_MENU_FILESEL_ACCEL(UI_MENU_PCX, "Save Screenshot", "F10"),
 		/* there isn't enough space for "PNG/PCX Interlaced Screenshot Shift+F10" */
@@ -4399,7 +4401,7 @@ void UI_Run(void)
 		case UI_MENU_DISPLAY:
 			DisplaySettings();
 			break;
-#ifndef DREAMCAST
+#ifdef SCREENSHOTS
 		case UI_MENU_PCX:
 			Screenshot(FALSE);
 			break;

--- a/src/ui.c
+++ b/src/ui.c
@@ -82,7 +82,7 @@
 #include "pokeysnd.h"
 #include "sound.h"
 #endif /* SOUND */
-#if defined(SOUND) || defined(VIDEO_RECORDING)
+#if defined(AUDIO_RECORDING) || defined(VIDEO_RECORDING)
 #include "file_export.h"
 #endif /* defined(SOUND) || defined(VIDEO_RECORDING) */
 #ifdef DIRECTX
@@ -1271,7 +1271,7 @@ static void CartManagement(void)
 	}
 }
 
-#if defined(SOUND) && !defined(DREAMCAST)
+#ifdef AUDIO_RECORDING
 static void SoundRecording(void)
 {
 	if (!Sound_enabled) {
@@ -1297,7 +1297,7 @@ static void SoundRecording(void)
 		UI_driver->fMessage("Recording stopped", 1);
 	}
 }
-#endif /* defined(SOUND) && !defined(DREAMCAST) */
+#endif /* AUDIO_RECORDING */
 
 #ifdef VIDEO_RECORDING
 static void VideoRecording(void)
@@ -4376,7 +4376,7 @@ void UI_Run(void)
 				done = TRUE;	/* reboot immediately */
 			}
 			break;
-#ifndef DREAMCAST
+#ifdef AUDIO_RECORDING
 		case UI_MENU_SOUND_RECORDING:
 			SoundRecording();
 			break;


### PR DESCRIPTION
Audio recording is now uncoupled from the `SOUND` constant so you can still have sound but not include the audio recording capability. Also added the `SCREENSHOTS` constant tied to the `--[dis|en]able-screenshots` configure argument. Both these constants also clean up the `#ifdef` blocks, because there were tests like `#if !defined(BASIC) && !defined(CURSES_BASIC)` that can now be replaced by tests like `#ifdef SCREENSHOTS`.

I decided not to add a `--disable-file-exports` because there are other things like save states that could be considered as exporting a file but that's not what was intended here. Hopefully adding `--disable-screenshots --disable-audiorecording --disable-videorecording` isn't too bad for the few platforms that are so space constrained that they would exclude all these super mega awesome features :smile:, because by default all those features are enabled.