### PR TITLE
Allow using Keyboard and SDL controllers as separate joysticks

### DIFF
--- a/DOC/CREDITS
+++ b/DOC/CREDITS
@@ -443,3 +443,6 @@ Marcin Zukowski <eru@ibb.waw.pl>
     - fix in ANTIC, GTIA
     - slight monitor improvement
     - fix in Atrax cartridge bank switching
+
+Martin von Gagern <martin@von-gagern.net>
+    - allow SDL joysticks to come after keyboard-emulated joysticks

--- a/DOC/USAGE
+++ b/DOC/USAGE
@@ -202,7 +202,6 @@ Command line options
 -multijoy             Emulate MultiJoy4 interface
 -directmouse          Use mouse's absolute position
 -cx85 <num>           Emulate CX85 numeric keypad on port <num>
--grabmouse            SDL only, prevent mouse pointer from leaving the window
 
 -record <filename>    Record input to <filename>
 -playback <filename>  Playback input from <filename>
@@ -363,6 +362,16 @@ SDL version options
 -nojoystick           Do not initialize joysticks
 -joy0 </dev/lp0>      Define the device for LPTjoy
 -joy1 </dev/lp1>      --""-- only when LPTjoy support compiled in
+-joy0hat              Use hat of joystick 0
+-joy1hat              Use hat of joystick 1
+-joy2hat              Use hat of joystick 2
+-joy3hat              Use hat of joystick 3
+-kbdjoy0              Enable joystick 0 keyboard emulation
+-kbdjoy1              Enable joystick 1 keyboard emulation
+-no-kbdjoy0           Disable joystick 0 keyboard emulation
+-no-kbdjoy1           Disable joystick 1 keyboard emulation
+-joy-distinct         Use one input device per emulated stick
+-grabmouse            Prevent mouse pointer from leaving window
 
 The following 7 items are only for -ntsc-artif set to ntsc-full:
 -ntsc-filter-preset composite|svideo|rgb|monochrome
@@ -594,6 +603,15 @@ freely defined in the config UI (Controller Config -> Define layout).
 Keyboard joystick emulation can be enabled/disabled in the Controller Config.
 By default, joy 0 is enabled and joy 1 is disabled (to not steal normal
 AWDS keys in the emulator).
+
+Usually the joysticks emulated by keyboard will overlap with any physical
+joysticks detected, so that you can freely switch between keyboard and joystick
+to control the emulation. However, if you want to emulate more than two
+joysticks, you can use -joy-distinct to place physical joysticks after the
+keyboard-emulated ones. This allows you to combine 1 or 2 keyboard-emulated
+joysticks with up to 3 SDL joysticks, but only up to a total of 4. The
+assignment is fixed at start-up and won't get updated if you enable or disable
+keyboard-emulated joysticks using the UI.
 
 
 X11 keyboard, joystick and other controllers

--- a/src/amiga/amiga.c
+++ b/src/amiga/amiga.c
@@ -95,15 +95,6 @@
 
 #include "Atari800_rev.h"
 
-
-/* joystick emulation
-   keys are loaded from config file
-   Here the defaults if there is no keymap in the config file... */
-
-/* a runtime switch for the kbd_joy_X_enabled vars is in the UI */
-int PLATFORM_kbd_joy_0_enabled = TRUE;	/* enabled by default, doesn't hurt */
-int PLATFORM_kbd_joy_1_enabled = FALSE;	/* disabled, would steal normal keys */
-
 /* real joysticks */
 
 static int fd_joystick0 = -1;

--- a/src/platform.h
+++ b/src/platform.h
@@ -66,8 +66,8 @@ void curses_display_line(int anticmode, const UBYTE *screendata);
 
 #ifdef GUI_SDL
 /* used in UI to show how the keyboard joystick is mapped */
-extern int PLATFORM_kbd_joy_0_enabled;
-extern int PLATFORM_kbd_joy_1_enabled;
+int PLATFORM_IsKbdJoystickEnabled(int num);
+void PLATFORM_ToggleKbdJoystickEnabled(int num);
 int PLATFORM_GetRawKey(void);
 #endif /* GUI_SDL */
 

--- a/src/sdl/input.c
+++ b/src/sdl/input.c
@@ -1480,103 +1480,52 @@ void SDL_INPUT_Restart(void)
 
 static int get_SDL_joystick_state(SDL_Joystick *joystick)
 {
-	int x;
-	int y;
-
-	x = SDL_JoystickGetAxis(joystick, 0);
-	y = SDL_JoystickGetAxis(joystick, 1);
-
-	if (x > minjoy) {
-		if (y < -minjoy)
-			return INPUT_STICK_UR;
-		else if (y > minjoy)
-			return INPUT_STICK_LR;
-		else
-			return INPUT_STICK_RIGHT;
-	}
-	else if (x < -minjoy) {
-		if (y < -minjoy)
-			return INPUT_STICK_UL;
-		else if (y > minjoy)
-			return INPUT_STICK_LL;
-		else
-			return INPUT_STICK_LEFT;
-	}
-	else {
-		if (y < -minjoy)
-			return INPUT_STICK_FORWARD;
-		else if (y > minjoy)
-			return INPUT_STICK_BACK;
-		else
-			return INPUT_STICK_CENTRE;
-	}
+	int x = SDL_JoystickGetAxis(joystick, 0);
+	int y = SDL_JoystickGetAxis(joystick, 1);
+	int stick = INPUT_STICK_CENTRE;
+	if (x > minjoy)
+		stick &= INPUT_STICK_RIGHT;
+	else if (x < -minjoy)
+		stick &= INPUT_STICK_LEFT;
+	if (y > minjoy)
+		stick &= INPUT_STICK_BACK;
+	else if (y < -minjoy)
+		stick &= INPUT_STICK_FORWARD;
+	return stick;
 }
 
 static int get_SDL_joystick_hat_state(SDL_Joystick* joystick)
 {
 	Uint8 hat = SDL_JoystickGetHat(joystick, 0);
-
-	if ((hat & SDL_HAT_LEFT)==SDL_HAT_LEFT) {
-		if ((hat & SDL_HAT_LEFTDOWN)==SDL_HAT_LEFTDOWN) return INPUT_STICK_LL;
-		if ((hat & SDL_HAT_LEFTUP)==SDL_HAT_LEFTUP) return INPUT_STICK_UL;
-		return INPUT_STICK_LEFT;
-	}
-	else if ((hat & SDL_HAT_RIGHT)==SDL_HAT_RIGHT) {
-		if ((hat & SDL_HAT_RIGHTDOWN)==SDL_HAT_RIGHTDOWN) return INPUT_STICK_LR;
-		else if ((hat & SDL_HAT_RIGHTUP)==SDL_HAT_RIGHTUP) return INPUT_STICK_UR;
-		return INPUT_STICK_RIGHT;
-	}
-	else if ((hat & SDL_HAT_UP)==SDL_HAT_UP) {
-		return INPUT_STICK_FORWARD;
-	}
-	else if ((hat & SDL_HAT_DOWN)==SDL_HAT_DOWN) {
-		return INPUT_STICK_BACK;
-	}
-
-	return INPUT_STICK_CENTRE;
+	int stick = INPUT_STICK_CENTRE;
+	if (hat & SDL_HAT_LEFT)
+		stick &= INPUT_STICK_LEFT;
+	if (hat & SDL_HAT_RIGHT)
+		stick &= INPUT_STICK_RIGHT;
+	if (hat & SDL_HAT_UP)
+		stick &= INPUT_STICK_FORWARD;
+	if (hat & SDL_HAT_DOWN)
+		stick &= INPUT_STICK_BACK;
+	return stick;
 }
 
 static int get_LPT_joystick_state(int fd)
 {
 #ifdef LPTJOY
-	int status;
+	int status, stick;
 
 	ioctl(fd, LPGETSTATUS, &status);
 	status ^= 0x78;
-
-	if (status & 0x40) {			/* right */
-		if (status & 0x10) {		/* up */
-			return INPUT_STICK_UR;
-		}
-		else if (status & 0x20) {	/* down */
-			return INPUT_STICK_LR;
-		}
-		else {
-			return INPUT_STICK_RIGHT;
-		}
-	}
-	else if (status & 0x80) {		/* left */
-		if (status & 0x10) {		/* up */
-			return INPUT_STICK_UL;
-		}
-		else if (status & 0x20) {	/* down */
-			return INPUT_STICK_LL;
-		}
-		else {
-			return INPUT_STICK_LEFT;
-		}
-	}
-	else {
-		if (status & 0x10) {		/* up */
-			return INPUT_STICK_FORWARD;
-		}
-		else if (status & 0x20) {	/* down */
-			return INPUT_STICK_BACK;
-		}
-		else {
-			return INPUT_STICK_CENTRE;
-		}
-	}
+	stick = INPUT_STICK_CENTRE;
+	if (status & 0x80)
+		stick &= INPUT_STICK_LEFT;
+	if (status & 0x40)
+		stick &= INPUT_STICK_RIGHT;
+	if (status & 0x20)
+		stick &= INPUT_STICK_BACK;
+	if (status & 0x10)
+		stick &= INPUT_STICK_FORWARD;
+	return stick;
 #else
 	return 0;
 #endif /* LPTJOY */

--- a/src/ui.c
+++ b/src/ui.c
@@ -3967,8 +3967,8 @@ static void ControllerConfiguration(void)
 		mouse_speed_status[0] = (char) ('0' + INPUT_mouse_speed);
 #endif
 #ifdef GUI_SDL
-		SetItemChecked(menu_array, 5, PLATFORM_kbd_joy_0_enabled);
-		SetItemChecked(menu_array, 7, PLATFORM_kbd_joy_1_enabled);
+		SetItemChecked(menu_array, 5, PLATFORM_IsKbdJoystickEnabled(0));
+		SetItemChecked(menu_array, 7, PLATFORM_IsKbdJoystickEnabled(1));
 #endif
 #ifdef DIRECTX
 		menu_array[5].suffix = keyboard_joystick_mode_array[keyboardJoystickMode].item;
@@ -4023,13 +4023,13 @@ static void ControllerConfiguration(void)
 #endif
 #ifdef GUI_SDL
 		case 5:
-			PLATFORM_kbd_joy_0_enabled = !PLATFORM_kbd_joy_0_enabled;
+			PLATFORM_ToggleKbdJoystickEnabled(0);
 			break;
 		case 6:
 			KeyboardJoystickConfiguration(0);
 			break;
 		case 7:
-			PLATFORM_kbd_joy_1_enabled = !PLATFORM_kbd_joy_1_enabled;
+			PLATFORM_ToggleKbdJoystickEnabled(1);
 			break;
 		case 8:
 			KeyboardJoystickConfiguration(1);


### PR DESCRIPTION
Having [read about M.U.L.E.](https://www.filfre.net/2013/02/dan-bunten-and-m-u-l-e/), I wanted to give that a try with a group of 4 players. 3 controllers and 1 keyboard, or so I hoped. But it didn't work out. And it took considerable working with the code and some recorded inputs to figure out that both the keyboard and the first SDL device were controlling the emulated joystick 0, while nothing was controlling the emulated joystick 3. Pity.

So I wrote some code to change that. This pull request introduces a new command line flag `-joy-distinct` which places the physical SDL devices *after* the keyboard-emulated devices, based on which keyboard-emulated devices are enabled at the time the config file and command line flags have been processed. This doesn't achieve full control over freely mapping which combinations of physical devices should control which emulated joysticks at which point in time, but it's a start and good enough for my use case. Extended logging output will make the assignments clearer and hopefully help future users who might get surprised by the default behavior the way I was surprised.

Reading the existing code I found that a lot of places were making very non-trivial assumptions about which kinds of host devices could be associated with which emulated controller. Different arrays were linked by index in various places. The possibility of having LPT joysticks and an on-screen keyboard (OSK) thrown in didn't make things any simpler. So the first commit of this request is a fairly wide-ranging change to simplify the abstraction of an emulated device without introducing any actual changes in observed behavior. A later commit then performs the changes based on the setting of the flag. One commit is a drive-by improvement by means of bit field arithmetic which is not really related to this PR except that I happened to look at that code and see a potential for simplification. Readers may choose to look at the commits in isolation to separate these aspects. The commit descriptions have more details which I won't repeat here.