### PR TITLE
Also swap SDL joysticks on AltL+J

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /src/android/proguard-project.txt
 src/guess_settings
 src/libatari800_test
+/tools/cart
 /config.log
 /config.status
 /configure

--- a/src/input.c
+++ b/src/input.c
@@ -463,7 +463,7 @@ void INPUT_Frame(void)
 		sscanf(gzbuf, "%d %d %d ", &INPUT_key_code, &INPUT_key_shift, &INPUT_key_consol);
 	}
 	if (recording) {
-		gzprintf(recordfp, "%d %d %d \n", INPUT_key_code, INPUT_key_shift, INPUT_key_consol);
+		gzprintf(recordfp, "%d %d %d ", INPUT_key_code, INPUT_key_shift, INPUT_key_consol);
 	}
 #endif
 	i = Atari800_machine_type == Atari800_MACHINE_5200 ? INPUT_key_shift : (INPUT_key_code == AKEY_BREAK);
@@ -551,7 +551,7 @@ void INPUT_Frame(void)
 #ifdef EVENT_RECORDING
 	}
 	if (recording) {
-		gzprintf(recordfp,"%d \n",i);
+		gzprintf(recordfp,"%d ",i);
 	}
 #endif
 
@@ -567,7 +567,7 @@ void INPUT_Frame(void)
 #ifdef EVENT_RECORDING
 	}
 	if (recording) {
-		gzprintf(recordfp,"%d \n",i);
+		gzprintf(recordfp,"%d ",i);
 	}
 #endif
 	STICK[2] = i & 0x0f;
@@ -612,12 +612,17 @@ void INPUT_Frame(void)
 #ifdef EVENT_RECORDING
 		}
 		if(recording){
-			gzprintf(recordfp,"%d \n",TRIG_input[i]);
+			gzprintf(recordfp,"%d ",TRIG_input[i]);
 		}
 #endif
 		if ((INPUT_joy_autofire[i] == INPUT_AUTOFIRE_FIRE && !TRIG_input[i]) || (INPUT_joy_autofire[i] == INPUT_AUTOFIRE_CONT))
 			TRIG_input[i] = (Atari800_nframes & 2) ? 1 : 0;
 	}
+#ifdef EVENT_RECORDING
+	if(recording){
+		gzprintf(recordfp,"\n");
+	}
+#endif
 
 	/* handle analog joysticks in Atari 5200 */
 	if (Atari800_machine_type != Atari800_MACHINE_5200) {

--- a/src/sdl/input.c
+++ b/src/sdl/input.c
@@ -370,8 +370,12 @@ void PLATFORM_GetJoystickKeyName(int joystick, int direction, char *buffer, int 
 
 static void SwapJoysticks(void)
 {
+	/* Struct assignment is like memcpy, will swap all fields. */
+	struct stick_dev tmp = stick_devs[0];
+	stick_devs[0] = stick_devs[1];
+	stick_devs[1] = tmp;
 	swap_joysticks = 1 - swap_joysticks;
-	update_kbd_sticks();
+	/* No need to call update_kbd_sticks, we did everything we needed. */
 }
 
 int PLATFORM_GetRawKey(void)


### PR DESCRIPTION
This swaps all physical devices connected to the first two emulated joysticks: the keyboard keys, the SDL devices, and the LPT devices.

After the swap the real joystick / hat setting in the UI will appear swapped as well, but the keyboard setting won't.  Changing that would require one more indirection. I might do something like that as part of a revamped UI integration in a future PR.

The PR includes two drive-by improvements which are not strictly related to the feature in question. See their commit messages.

Fixes https://github.com/atari800/atari800/issues/156.