### PR TITLE
Added H: device rename; save it in setup file

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -180,6 +180,8 @@ int CFG_LoadConfig(const char *alternate_config_filename)
 				Util_strlcpy(Devices_atari_h_dir[3], ptr, FILENAME_MAX);
 			else if (strcmp(string, "HD_READ_ONLY") == 0)
 				Devices_h_read_only = Util_sscandec(ptr);
+			else if (strcmp(string, "HD_DEVICE_NAME") == 0)
+				Devices_h_device_name = *ptr;
 
 			else if (strcmp(string, "PRINT_COMMAND") == 0) {
 				if (!Devices_SetPrintCommand(ptr))
@@ -397,6 +399,7 @@ int CFG_WriteConfig(void)
 	for (i = 0; i < 4; i++)
 		fprintf(fp, "H%c_DIR=%s\n", '1' + i, Devices_atari_h_dir[i]);
 	fprintf(fp, "HD_READ_ONLY=%d\n", Devices_h_read_only);
+	fprintf(fp, "HD_DEVICE_NAME=%c\n", Devices_h_device_name);
 
 #ifdef HAVE_SYSTEM
 	fprintf(fp, "PRINT_COMMAND=%s\n", Devices_print_command);

--- a/src/devices.c
+++ b/src/devices.c
@@ -626,7 +626,7 @@ int Devices_Initialise(int *argc, char *argv[])
 				Log_print("\t-H3 <path>       Set path for H3: device");
 				Log_print("\t-H4 <path>       Set path for H4: device");
 				Log_print("\t-Hpath <path>    Set path for Atari executables on the H: device");
-				Log_print("\t-Hdevicename <X> Rename H: device for something different");
+				Log_print("\t-Hdevicename <X> Use this letter to access the Host device, instead of H:");
 				Log_print("\t-hreadonly       Enable read-only mode for H: device");
 				Log_print("\t-hreadwrite      Disable read-only mode for H: device");
 				Log_print("\t-devbug          Debugging messages for H: and P: devices");

--- a/src/devices.h
+++ b/src/devices.h
@@ -22,6 +22,8 @@ extern int Devices_h_read_only;
 
 extern char Devices_h_exe_path[FILENAME_MAX];
 
+extern char Devices_h_device_name;
+
 extern char Devices_h_current_dir[4][FILENAME_MAX];
 
 int Devices_H_CountOpen(void);


### PR DESCRIPTION
I have added the commandline arg: -Hdevicename <X>, for example -Hdevicename D - which let me run a game that is a DOS dependent without DOS.
Only first non-space character will be a device name.
However, there is completely no checking what user entered.  But the same is in other options, so I let it stay like that. In case the device exists in HATABS, the duplicate will be added.

In the future, an option in menu may be added. 