### PR TITLE
Fixes CTRL and CAPS keys when using SDL12-compat library.

### DIFF
--- a/src/sdl/input.c
+++ b/src/sdl/input.c
@@ -437,16 +437,6 @@ int PLATFORM_Keyboard(void)
 	static int resize_w, resize_h;
 #endif /* HAVE_WINDOWS_H */
 
-	/* Very ugly fix for SDL CAPSLOCK brokenness.  This will let the user
-	 * press CAPSLOCK and get a brief keypress on the Atari but it is not
-	 * possible to emulate holding down CAPSLOCK for longer periods with
-	 * the broken SDL*/
-	if (lastkey == SDLK_CAPSLOCK) {
-		lastkey = SDLK_UNKNOWN;
-		key_pressed = 0;
- 		lastuni = 0;
-	}
-
 	while (SDL_PollEvent(&event)) {
 		event_found = 1;
 		switch (event.type) {
@@ -473,12 +463,6 @@ int PLATFORM_Keyboard(void)
 			lastkey = event.key.keysym.sym;
  			lastuni = 0; /* event.key.keysym.unicode is not defined for KEYUP */
 			key_pressed = 0;
-			/* ugly hack to fix broken SDL CAPSLOCK*/
-			/* Because SDL is only sending Keydown and keyup for every change
-			 * of state of the CAPSLOCK status, rather than the actual key.*/
-			if(lastkey == SDLK_CAPSLOCK) {
-				key_pressed = 1;
-			}
 			break;
 		case SDL_VIDEORESIZE:
 #if HAVE_WINDOWS_H
@@ -891,10 +875,7 @@ int PLATFORM_Keyboard(void)
 	case SDLK_LSUPER:
 		return AKEY_ATARI ^ shiftctrl;
 	case SDLK_RSUPER:
-		if (INPUT_key_shift)
-			return AKEY_CAPSLOCK;
-		else
-			return AKEY_CAPSTOGGLE;
+		return AKEY_CAPSTOGGLE;
 	case SDLK_END:
 	case SDLK_PAGEDOWN:
 		return AKEY_F2 | AKEY_SHFT;
@@ -904,10 +885,7 @@ int PLATFORM_Keyboard(void)
 		return key_control ? AKEY_LESS|shiftctrl : AKEY_CLEAR;
 	case SDLK_PAUSE:
 	case SDLK_CAPSLOCK:
-		if (INPUT_key_shift)
-			return AKEY_CAPSLOCK|shiftctrl;
-		else
-			return AKEY_CAPSTOGGLE|shiftctrl;
+		return AKEY_CAPSTOGGLE|shiftctrl;
 	case SDLK_SPACE:
 		return AKEY_SPACE ^ shiftctrl;
 	case SDLK_BACKSPACE:
@@ -1105,57 +1083,57 @@ int PLATFORM_Keyboard(void)
 	case 26:
 		return AKEY_CTRL_z|shiftctrl;
 	case 'A':
-		return AKEY_A;
+		return AKEY_A|shiftctrl;
 	case 'B':
-		return AKEY_B;
+		return AKEY_B|shiftctrl;
 	case 'C':
-		return AKEY_C;
+		return AKEY_C|shiftctrl;
 	case 'D':
-		return AKEY_D;
+		return AKEY_D|shiftctrl;
 	case 'E':
-		return AKEY_E;
+		return AKEY_E|shiftctrl;
 	case 'F':
-		return AKEY_F;
+		return AKEY_F|shiftctrl;
 	case 'G':
-		return AKEY_G;
+		return AKEY_G|shiftctrl;
 	case 'H':
-		return AKEY_H;
+		return AKEY_H|shiftctrl;
 	case 'I':
-		return AKEY_I;
+		return AKEY_I|shiftctrl;
 	case 'J':
-		return AKEY_J;
+		return AKEY_J|shiftctrl;
 	case 'K':
-		return AKEY_K;
+		return AKEY_K|shiftctrl;
 	case 'L':
-		return AKEY_L;
+		return AKEY_L|shiftctrl;
 	case 'M':
-		return AKEY_M;
+		return AKEY_M|shiftctrl;
 	case 'N':
-		return AKEY_N;
+		return AKEY_N|shiftctrl;
 	case 'O':
-		return AKEY_O;
+		return AKEY_O|shiftctrl;
 	case 'P':
-		return AKEY_P;
+		return AKEY_P|shiftctrl;
 	case 'Q':
-		return AKEY_Q;
+		return AKEY_Q|shiftctrl;
 	case 'R':
-		return AKEY_R;
+		return AKEY_R|shiftctrl;
 	case 'S':
-		return AKEY_S;
+		return AKEY_S|shiftctrl;
 	case 'T':
-		return AKEY_T;
+		return AKEY_T|shiftctrl;
 	case 'U':
-		return AKEY_U;
+		return AKEY_U|shiftctrl;
 	case 'V':
-		return AKEY_V;
+		return AKEY_V|shiftctrl;
 	case 'W':
-		return AKEY_W;
+		return AKEY_W|shiftctrl;
 	case 'X':
-		return AKEY_X;
+		return AKEY_X|shiftctrl;
 	case 'Y':
-		return AKEY_Y;
+		return AKEY_Y|shiftctrl;
 	case 'Z':
-		return AKEY_Z;
+		return AKEY_Z|shiftctrl;
 	case ':':
 		return AKEY_COLON;
 	case '!':
@@ -1191,57 +1169,57 @@ int PLATFORM_Keyboard(void)
 	case '>':
 		return AKEY_GREATER;
 	case 'a':
-		return AKEY_a;
+		return AKEY_a|shiftctrl;
 	case 'b':
-		return AKEY_b;
+		return AKEY_b|shiftctrl;
 	case 'c':
-		return AKEY_c;
+		return AKEY_c|shiftctrl;
 	case 'd':
-		return AKEY_d;
+		return AKEY_d|shiftctrl;
 	case 'e':
-		return AKEY_e;
+		return AKEY_e|shiftctrl;
 	case 'f':
-		return AKEY_f;
+		return AKEY_f|shiftctrl;
 	case 'g':
-		return AKEY_g;
+		return AKEY_g|shiftctrl;
 	case 'h':
-		return AKEY_h;
+		return AKEY_h|shiftctrl;
 	case 'i':
-		return AKEY_i;
+		return AKEY_i|shiftctrl;
 	case 'j':
-		return AKEY_j;
+		return AKEY_j|shiftctrl;
 	case 'k':
-		return AKEY_k;
+		return AKEY_k|shiftctrl;
 	case 'l':
-		return AKEY_l;
+		return AKEY_l|shiftctrl;
 	case 'm':
-		return AKEY_m;
+		return AKEY_m|shiftctrl;
 	case 'n':
-		return AKEY_n;
+		return AKEY_n|shiftctrl;
 	case 'o':
-		return AKEY_o;
+		return AKEY_o|shiftctrl;
 	case 'p':
-		return AKEY_p;
+		return AKEY_p|shiftctrl;
 	case 'q':
-		return AKEY_q;
+		return AKEY_q|shiftctrl;
 	case 'r':
-		return AKEY_r;
+		return AKEY_r|shiftctrl;
 	case 's':
-		return AKEY_s;
+		return AKEY_s|shiftctrl;
 	case 't':
-		return AKEY_t;
+		return AKEY_t|shiftctrl;
 	case 'u':
-		return AKEY_u;
+		return AKEY_u|shiftctrl;
 	case 'v':
-		return AKEY_v;
+		return AKEY_v|shiftctrl;
 	case 'w':
-		return AKEY_w;
+		return AKEY_w|shiftctrl;
 	case 'x':
-		return AKEY_x;
+		return AKEY_x|shiftctrl;
 	case 'y':
-		return AKEY_y;
+		return AKEY_y|shiftctrl;
 	case 'z':
-		return AKEY_z;
+		return AKEY_z|shiftctrl;
 	case ';':
 		return AKEY_SEMICOLON;
 	case '0':


### PR DESCRIPTION
This also simplifies the code, as the new SDL key handling is saner. Fixes atari800/atari800#177