### PR TITLE
fixed .h .c function declaration matching resulted in warnings

### DIFF
--- a/src/colours_ntsc.c
+++ b/src/colours_ntsc.c
@@ -212,7 +212,7 @@ void COLOURS_NTSC_RestoreDefaults(void)
 	COLOURS_NTSC_setup.color_delay = default_setup.color_delay;
 }
 
-Colours_preset_t COLOURS_NTSC_GetPreset()
+Colours_preset_t COLOURS_NTSC_GetPreset(void)
 {
 	if (Util_almostequal(COLOURS_NTSC_setup.color_delay, default_setup.color_delay, 0.001))
 		return COLOURS_PRESET_STANDARD;

--- a/src/colours_pal.c
+++ b/src/colours_pal.c
@@ -383,7 +383,7 @@ void COLOURS_PAL_RestoreDefaults(void)
 	COLOURS_PAL_setup.color_delay = default_setup.color_delay;
 }
 
-Colours_preset_t COLOURS_PAL_GetPreset()
+Colours_preset_t COLOURS_PAL_GetPreset(void)
 {
 	if (Util_almostequal(COLOURS_PAL_setup.color_delay, default_setup.color_delay, 0.001))
 		return COLOURS_PRESET_STANDARD;

--- a/src/file_export.c
+++ b/src/file_export.c
@@ -323,7 +323,7 @@ int File_Export_GetNextVideoFile(char *buffer, int bufsize) {
    RETURNS: non-zero if successfully added the video frame to the file
    (indicating the size of the video frame in bytes) or 0 if failed when
    creating the video frame or adding it to the file. */
-int File_Export_WriteVideo()
+int File_Export_WriteVideo(void)
 {
 	int result;
 

--- a/src/pbi_xld.c
+++ b/src/pbi_xld.c
@@ -194,7 +194,7 @@ int PBI_XLD_D1GetByte(UWORD addr)
 
 
 /* D1FF: each bit indicates IRQ status of a device */
-UBYTE PBI_XLD_D1ffGetByte()
+UBYTE PBI_XLD_D1ffGetByte(void)
 {
 	UBYTE result = 0;
 	/* VOTRAX BUSY IRQ bit */

--- a/src/videomode.c
+++ b/src/videomode.c
@@ -1246,7 +1246,7 @@ int VIDEOMODE_InitialiseDisplay(void)
 	return TRUE;
 }
 
-void VIDEOMODE_Exit()
+void VIDEOMODE_Exit(void)
 {
 	if (resolutions != NULL)
 		free(resolutions);


### PR DESCRIPTION
removed 5 warnings during compilation.