### PR TITLE
Add menu option to set 'H' device letter.

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -2212,7 +2212,6 @@ static void AtariSettings(void)
 		UI_MENU_CHECK(3, "SIO patch (fast disk access):"),
 		UI_MENU_CHECK(17, "Turbo (F12):"),
 		UI_MENU_CHECK(19, "Slow booting of DOS binary files:"),
-		UI_MENU_ACTION(4, "H: device (hard disk):"),
 		UI_MENU_CHECK(5, "P: device (printer):"),
 #ifdef R_IO_DEVICE
 #ifdef DREAMCAST
@@ -2221,11 +2220,13 @@ static void AtariSettings(void)
 		UI_MENU_CHECK(6, "R: device (Atari850 via net):"),
 #endif
 #endif
-		UI_MENU_FILESEL_PREFIX(7, "H1: ", Devices_atari_h_dir[0]),
-		UI_MENU_FILESEL_PREFIX(8, "H2: ", Devices_atari_h_dir[1]),
-		UI_MENU_FILESEL_PREFIX(9, "H3: ", Devices_atari_h_dir[2]),
-		UI_MENU_FILESEL_PREFIX(10, "H4: ", Devices_atari_h_dir[3]),
-		UI_MENU_SUBMENU(11, "Advanced H: options"),
+		UI_MENU_ACTION(4, "Host device enabled:"),
+		UI_MENU_ACTION(20, " Host device SIO letter:"),
+		UI_MENU_FILESEL_PREFIX(7, " Host dev 1 path: ", Devices_atari_h_dir[0]),
+		UI_MENU_FILESEL_PREFIX(8, " Host dev 2 path: ", Devices_atari_h_dir[1]),
+		UI_MENU_FILESEL_PREFIX(9, " Host dev 3 path: ", Devices_atari_h_dir[2]),
+		UI_MENU_FILESEL_PREFIX(10, " Host dev 4 path: ", Devices_atari_h_dir[3]),
+		UI_MENU_SUBMENU(11, " Host device status..."),
 		UI_MENU_ACTION_PREFIX(12, "Print command: ", Devices_print_command),
 		UI_MENU_SUBMENU(13, "System ROM settings"),
 		UI_MENU_SUBMENU(14, "Configure directories"),
@@ -2236,6 +2237,7 @@ static void AtariSettings(void)
 		UI_MENU_END
 	};
 	char tmp_command[256];
+	char hdev_option[4];
 
 	int option = 0;
 
@@ -2251,6 +2253,9 @@ static void AtariSettings(void)
 		SetItemChecked(menu_array, 17, Atari800_turbo);
 		SetItemChecked(menu_array, 19, BINLOAD_slow_xex_loading);
 		FindMenuItem(menu_array, 4)->suffix = Devices_enable_h_patch ? (Devices_h_read_only ? "Read-only" : "Read/write") : "No ";
+		strcpy(hdev_option + 1, ":");
+		hdev_option[0] = Devices_h_device_name;
+		FindMenuItem(menu_array, 20)->suffix = hdev_option;
 		SetItemChecked(menu_array, 5, Devices_enable_p_patch);
 #ifdef R_IO_DEVICE
 		SetItemChecked(menu_array, 6, Devices_enable_r_patch);
@@ -2345,6 +2350,13 @@ static void AtariSettings(void)
 #endif /* XEP80_EMULATION */
 		case 19:
 			BINLOAD_slow_xex_loading = !BINLOAD_slow_xex_loading;
+			break;
+		case 20:
+			do {
+				Devices_h_device_name ++;
+				if( Devices_h_device_name > 'Z' )
+					Devices_h_device_name = 'A';
+			} while ( strchr("CEKS", Devices_h_device_name) );
 			break;
 		default:
 			ESC_UpdatePatches();

--- a/src/ui.c
+++ b/src/ui.c
@@ -1683,17 +1683,19 @@ static void TapeManagement(void)
 
 }
 
-static void AdvancedHOptions(void)
+static void HDeviceStatus(void)
 {
-	static char open_info[] = "0 currently open files";
+	static char open_info[] = " 0 currently open files";
 	static UI_tMenuItem menu_array[] = {
-		UI_MENU_ACTION(0, "Atari executables path"),
+		UI_MENU_LABEL("Atari executable path:"),
+        UI_MENU_ACTION_PREFIX(0, " ", Devices_h_exe_path),
+		UI_MENU_LABEL("File status:"),
 		UI_MENU_ACTION_TIP(1, open_info, NULL),
 		UI_MENU_LABEL("Current directories:"),
-		UI_MENU_ACTION_PREFIX_TIP(2, "H1:", Devices_h_current_dir[0], NULL),
-		UI_MENU_ACTION_PREFIX_TIP(3, "H2:", Devices_h_current_dir[1], NULL),
-		UI_MENU_ACTION_PREFIX_TIP(4, "H3:", Devices_h_current_dir[2], NULL),
-		UI_MENU_ACTION_PREFIX_TIP(5, "H4:", Devices_h_current_dir[3], NULL),
+		UI_MENU_ACTION_PREFIX_TIP(2, " Host dev 1:", Devices_h_current_dir[0], NULL),
+		UI_MENU_ACTION_PREFIX_TIP(3, " Host dev 2:", Devices_h_current_dir[1], NULL),
+		UI_MENU_ACTION_PREFIX_TIP(4, " Host dev 3:", Devices_h_current_dir[2], NULL),
+		UI_MENU_ACTION_PREFIX_TIP(5, " Host dev 4:", Devices_h_current_dir[3], NULL),
 		UI_MENU_END
 	};
 	int option = 0;
@@ -1701,12 +1703,12 @@ static void AdvancedHOptions(void)
 		int i;
 		int seltype;
 		i = Devices_H_CountOpen();
-		open_info[0] = (char) ('0' + i);
-		open_info[21] = (i != 1) ? 's' : '\0';
+		open_info[1] = (char) ('0' + i);
+		open_info[22] = (i != 1) ? 's' : '\0';
 		menu_array[1].suffix = (i > 0) ? ((i == 1) ? "Backspace: close" : "Backspace: close all") : NULL;
 		for (i = 0; i < 4; i++)
 			menu_array[3 + i].suffix = Devices_h_current_dir[i][0] != '\0' ? "Backspace: reset to root" : NULL;
-		option = UI_driver->fSelect("Advanced H: options", 0, option, menu_array, &seltype);
+		option = UI_driver->fSelect("Host device status", 0, option, menu_array, &seltype);
 		switch (option) {
 		case 0:
 			{
@@ -2308,7 +2310,7 @@ static void AtariSettings(void)
 				UI_driver->fGetDirectoryPath(FindMenuItem(menu_array, option)->item);
 			break;
 		case 11:
-			AdvancedHOptions();
+			HDeviceStatus();
 			break;
 		case 12:
 			strcpy(tmp_command, Devices_print_command);

--- a/src/ui.c
+++ b/src/ui.c
@@ -2215,6 +2215,7 @@ static void AtariSettings(void)
 		UI_MENU_CHECK(17, "Turbo (F12):"),
 		UI_MENU_CHECK(19, "Slow booting of DOS binary files:"),
 		UI_MENU_CHECK(5, "P: device (printer):"),
+		UI_MENU_ACTION_PREFIX(12, " Print command: ", Devices_print_command),
 #ifdef R_IO_DEVICE
 #ifdef DREAMCAST
 		UI_MENU_CHECK(6, "R: device (using Coder's Cable):"),
@@ -2229,7 +2230,6 @@ static void AtariSettings(void)
 		UI_MENU_FILESEL_PREFIX(9, " Host dev 3 path: ", Devices_atari_h_dir[2]),
 		UI_MENU_FILESEL_PREFIX(10, " Host dev 4 path: ", Devices_atari_h_dir[3]),
 		UI_MENU_SUBMENU(11, " Host device status..."),
-		UI_MENU_ACTION_PREFIX(12, "Print command: ", Devices_print_command),
 		UI_MENU_SUBMENU(13, "System ROM settings"),
 		UI_MENU_SUBMENU(14, "Configure directories"),
 #ifndef DREAMCAST

--- a/src/ui.c
+++ b/src/ui.c
@@ -1734,11 +1734,18 @@ static void HDeviceStatus(void)
 			}
 			break;
 		case 1:
-			do {
-				Devices_h_device_name ++;
-				if( Devices_h_device_name > 'Z' )
-					Devices_h_device_name = 'A';
-			} while ( strchr("CEKS", Devices_h_device_name) );
+			if (seltype == UI_USER_DELETE)
+				Devices_h_device_name = 'H';
+			else {
+				hdev_option[1] = 0;
+				UI_driver->fEditString("Host Device SIO Letter:", hdev_option, 2);
+				if( hdev_option[0] >= 'a' && hdev_option[0] <= 'z' )
+					hdev_option[0] -= 'a' - 'A';
+				if( !strchr("CEKS", hdev_option[0]) )
+					Devices_h_device_name = hdev_option[0];
+				else
+					UI_driver->fMessage("Invalid device letter", 1);
+			}
 			break;
 		case 2:
 		case 3:


### PR DESCRIPTION
Also, rename 'hard disk' to 'host device', that better describes what this device does, and reorder the options to logically group together the 'H' ones.

This is a WIP for the discussion at pull #204 