### PR TITLE
Close SDL audio subsystem when entering monitor

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,7 +97,7 @@ atari800_SOURCES += \
 	sndsave.c sndsave.h
 endif
 if WITH_SOUND_SDL
-atari800_SOURCES += sound.c sound.h sdl/sound.c
+atari800_SOURCES += sound.c sound.h sdl/sound.c sdl/sound.h
 endif
 if WITH_SOUND_FALCON
 atari800_SOURCES += sound.c falcon/sound.c

--- a/src/sdl/main.c
+++ b/src/sdl/main.c
@@ -43,6 +43,7 @@
 #include "platform.h"
 #ifdef SOUND
 #include "../sound.h"
+#include "sdl/sound.h"
 #endif
 #ifdef USE_UI_BASIC_ONSCREEN_KEYBOARD
 #include "akey.h"
@@ -113,7 +114,11 @@ int PLATFORM_Exit(int run_monitor)
 
 	if (run_monitor) {
 #ifdef SOUND
-		Sound_Pause();
+		/* Issue #97: On some Linux systems merely pausing SDL audio while SDL
+		   video is disabled, causes CPU usage to jump to 100% after a few
+		   minutes. Avoid the issue by closing SDL audio as well - call
+		   SDL_SOUND_HardPause instead of Sound_Pause. */
+		SDL_SOUND_HardPause();
 #endif
 		if (MONITOR_Run()) {
 			/* Reinitialise the SDL subsystem. */
@@ -126,9 +131,11 @@ int PLATFORM_Exit(int run_monitor)
 				/* This call reopens the SDL window. */
 				VIDEOMODE_Update();
 			}
-	#ifdef SOUND
-			Sound_Continue();
-	#endif
+#ifdef SOUND
+			/* Issue #97 (see above): Call SDL_SOUND_HardContinue instead of
+			   Sound_Continue. */
+			SDL_SOUND_HardContinue();
+#endif
 			return 1;
 		}
 	}

--- a/src/sdl/sound.h
+++ b/src/sdl/sound.h
@@ -1,0 +1,9 @@
+#ifndef SDL_SOUND_H_
+#define SDL_SOUND_H_
+
+/* Pause and close SDL audio. Required by Issue #97. */
+void SDL_SOUND_HardPause(void);
+/* Reopen and continue SDL audio. Required by Issue #97. */
+void SDL_SOUND_HardContinue(void);
+
+#endif /* SDL_SOUND_H_ */


### PR DESCRIPTION
On some Linux systems merely pausing SDL audio while SDL video is disabled, causes CPU usage to jump to 100% after a few minutes. Avoid the issue by closing SDL audio when entering the monitor, and reopening it when exiting it.

Fixes #97.