### PR TITLE
don't fread 0 bytes when length of the FUJI chunk is 0

### DIFF
--- a/src/img_tape.c
+++ b/src/img_tape.c
@@ -179,11 +179,12 @@ IMG_TAPE_t *IMG_TAPE_Open(char const *filename, int *writable, char const **desc
 			skip = 0;
 		else
 			skip -= CASSETTE_DESCRIPTION_MAX - 1;
-		if (fread(img->description, 1, length - skip, img->file) < (length - skip)) {
-			fclose(img->file);
-			free(img);
-			return NULL;
-		}
+		if (length > 0)
+			if (fread(img->description, 1, length - skip, img->file) < (length - skip)) {
+				fclose(img->file);
+				free(img);
+				return NULL;
+			}
 		img->description[length - skip] = '\0';
 		fseek(img->file, skip, SEEK_CUR);
 


### PR DESCRIPTION
Ninja from Mastertronic from Atarimania https://www.atarimania.com/game-atari-400-800-xl-xe-ninja_3714.html doesn't want to be loaded. Short investigation appeared that this file hasn't got description and FUJI chunk contains length field set to 0, but atari800 calls fread with 0 bytes. Bugfix makes a call only when length is greater than 0 and Ninja works fine.