### PR TITLE
Add disk management and activity monitoring API to libatari800

### DIFF
--- a/src/libatari800/libatari800.h
+++ b/src/libatari800/libatari800.h
@@ -306,4 +306,14 @@ void libatari800_restore_state(emulator_state_t *state);
 
 void libatari800_exit();
 
+/* Disk management functions */
+int libatari800_mount_disk(int drive_num, const char *filename, int read_only);
+void libatari800_unmount_disk(int drive_num);
+void libatari800_disable_drive(int drive_num);
+void libatari800_set_disk_activity_callback(void (*callback)(int drive, int operation));
+
+/* SIO patch control functions */
+int libatari800_get_sio_patch_enabled(void);
+int libatari800_set_sio_patch_enabled(int enabled);
+
 #endif /* LIBATARI800_H_ */


### PR DESCRIPTION
Hi! I've been working on Fujisan, a Qt5-based frontend for the Atari 800 emulator, and ran into some limitations with the current libatari800 API. I needed to implement disk drive LED indicators and proper disk management UI, but there wasn't a clean way to do this without poking at internal structures.

I've added some disk management functions that I think other libatari800-based frontends could benefit from:

**Basic disk operations:**
```c
int libatari800_mount_disk(int drive_num, const char *filename, int read_only);
void libatari800_unmount_disk(int drive_num);
void libatari800_disable_drive(int drive_num);
```

**Real-time disk activity monitoring:**
```c
void libatari800_set_disk_activity_callback(void (*callback)(int drive, int operation));
```

This callback gets fired whenever there's actual disk I/O happening (reads/writes), which is perfect for updating LED indicators in real-time. The callback receives the drive number (1-8) and the operation type (read or write).

**SIO patch control:**
```c
int libatari800_get_sio_patch_enabled(void);
int libatari800_set_sio_patch_enabled(int enabled);
```

This lets frontends toggle between fast disk access (SIO patch enabled) and realistic hardware timing. Useful for games that depend on specific timing vs. just wanting fast loading in menus.

The disk activity callbacks are integrated directly into the SIO code - they fire during ReadSector, WriteSector, and CommandFrame operations. I've guarded everything with `#ifdef LIBATARI800` so it won't affect the regular atari800 build at all.

In Fujisan, I use the callback like this:
```c
void on_disk_activity(int drive, int operation) {
    update_led_indicator(drive, operation == SIO_LAST_READ ? LED_READ : LED_WRITE);
}
libatari800_set_disk_activity_callback(on_disk_activity);
```

Works great for showing real-time disk activity without having to poll for it.

Files changed:

- `src/libatari800/api.c` - implementation of the new functions
- `src/libatari800/libatari800.h` - API declarations  
- `src/sio.c` - hooked in the callbacks at the right spots

Everything builds cleanly with `./configure --target=libatari800 && make`.

Beyond Fujisan, I think this could help anyone building modern frontends that want:
- Visual feedback during disk operations (LEDs, progress indicators)
- Dynamic disk management without restart
- Control over emulation speed/accuracy tradeoffs

The callback approach is way more efficient than polling SIO variables every frame, and the mount/unmount functions provide a clean API instead of having to dig into SIO internals.

I've been using this in Fujisan for disk management and LED indicators - works well. The callbacks fire at the right times, and there's minimal performance impact since they only trigger during actual disk I/O.

One small note: there's a ULONG macro redefinition warning between atari.h and libatari800.h, but it's benign and doesn't affect functionality. I have a separate patch to clean that up if you're interested.

Let me know if you have questions or want me to change anything!