### PR TITLE
netsio: add startup wait and gate netstream mode via Fuji enable + motor + POKEY config

### DIFF
--- a/src/atari.c
+++ b/src/atari.c
@@ -149,6 +149,9 @@
 #endif
 #ifdef NETSIO
 #include "netsio.h"
+
+#define NETSIO_STARTUP_WAIT_TIMEOUT_MS 5000
+#define NETSIO_STARTUP_WAIT_POLL_MS 10
 #endif /* NETSIO */
 
 int Atari800_machine_type = Atari800_MACHINE_XLXE;
@@ -626,7 +629,17 @@ int Atari800_Initialise(int *argc, char *argv[])
 			if (netsio_init((uint16_t)port) < 0) {
 				Log_print("netsio: init failed");
 			} else {
+				int waited_ms = 0;
 				Log_print("netsio initialized with port %d", port);
+				while (!netsio_enabled && waited_ms < NETSIO_STARTUP_WAIT_TIMEOUT_MS) {
+					Util_sleep((double)NETSIO_STARTUP_WAIT_POLL_MS / 1000.0);
+					waited_ms += NETSIO_STARTUP_WAIT_POLL_MS;
+				}
+				if (netsio_enabled)
+					Log_print("netsio connected after %d ms", waited_ms);
+				else
+					Log_print("netsio not connected after %d ms, continuing startup",
+					          NETSIO_STARTUP_WAIT_TIMEOUT_MS);
 			}
 		}
 #endif /* NETSIO */

--- a/src/netsio.c
+++ b/src/netsio.c
@@ -42,6 +42,12 @@ volatile int netsio_sync_wait = 0;
 int netsio_cmd_state = 0;
 /* data frame size for SIO write commands */
 volatile int netsio_next_write_size = 0;
+/* Netstream gate state */
+static volatile int netsio_netstream_pending_enable = 0;
+static volatile int netsio_netstream_fuji_enabled = 0;
+static volatile int netsio_netstream_motor_on = 0;
+static volatile int netsio_netstream_pokey_ok = 0;
+static volatile int netsio_netstream_is_active = 0;
 
 /* PIA Pin buffered states for synchronous emulator polling */
 volatile int netsio_ca1_state = 1;
@@ -57,6 +63,26 @@ static socklen_t fujinet_addr_len = sizeof(fujinet_addr);
 
 /* Thread declaration */
 static void *fujinet_rx_thread(void *arg);
+
+static void netsio_netstream_recalc(void)
+{
+    int active = 0;
+    if (netsio_enabled
+     && netsio_netstream_fuji_enabled
+     && netsio_netstream_motor_on
+     && netsio_netstream_pokey_ok)
+        active = 1;
+    if (active != netsio_netstream_is_active) {
+        netsio_netstream_is_active = active;
+#ifdef DEBUG
+        Log_print("netsio: netstream %s (fuji=%d motor=%d pokey=%d)",
+            active ? "enter" : "exit",
+            netsio_netstream_fuji_enabled,
+            netsio_netstream_motor_on,
+            netsio_netstream_pokey_ok);
+#endif
+    }
+}
 
 static void millisleep(unsigned int ms)
 {
@@ -434,6 +460,63 @@ int netsio_motor_off(void)
     return 0;
 }
 
+void netsio_netstream_set_motor(int motor_on)
+{
+    netsio_netstream_motor_on = motor_on ? 1 : 0;
+    if (netsio_enabled) {
+        if (motor_on)
+            netsio_motor_on();
+        else
+            netsio_motor_off();
+    }
+    netsio_netstream_recalc();
+}
+
+void netsio_netstream_note_command_frame(const uint8_t *cmd, size_t len)
+{
+    if (len >= 2 && cmd != NULL && cmd[0] == 0x70 && cmd[1] == 0xF0) {
+        netsio_netstream_pending_enable = 1;
+#ifdef DEBUG
+        Log_print("netsio: netstream pending enable (cf 70/F0)");
+#endif
+    }
+}
+
+void netsio_netstream_note_status_byte(uint8_t status)
+{
+    if (!netsio_netstream_pending_enable)
+        return;
+    netsio_netstream_pending_enable = 0;
+    netsio_netstream_fuji_enabled = (status == 'A') ? 1 : 0;
+#ifdef DEBUG
+    Log_print("netsio: netstream enable %s (status=%02X)",
+        netsio_netstream_fuji_enabled ? "accepted" : "rejected",
+        status);
+#endif
+    netsio_netstream_recalc();
+}
+
+void netsio_netstream_clear_pending(void)
+{
+    netsio_netstream_pending_enable = 0;
+}
+
+void netsio_netstream_update_pokey(uint8_t skctl, uint8_t audctl, uint8_t audf3, uint8_t audf4)
+{
+    uint8_t mode = skctl & 0x70;
+    (void)audf3;
+    (void)audf4;
+    netsio_netstream_pokey_ok =
+        ((audctl & 0x28) == 0x28)
+        && (mode == 0x00 || mode == 0x10 || mode == 0x30 || mode == 0x40);
+    netsio_netstream_recalc();
+}
+
+int netsio_netstream_active(void)
+{
+    return netsio_netstream_is_active;
+}
+
 /* The emulator calls this to send a data byte out to FujiNet */
 int netsio_send_byte(uint8_t b) {
     uint8_t pkt[2];
@@ -496,6 +579,9 @@ int netsio_cold_reset(void) {
 #ifdef DEBUG
     Log_print("netsio: cold reset");
 #endif
+    netsio_netstream_pending_enable = 0;
+    netsio_netstream_fuji_enabled = 0;
+    netsio_netstream_recalc();
     send_to_fujinet(&pkt, 1);
     return 0;
 }
@@ -506,6 +592,9 @@ int netsio_warm_reset(void) {
 #ifdef DEBUG
     Log_print("netsio: warm reset");
 #endif
+    netsio_netstream_pending_enable = 0;
+    netsio_netstream_fuji_enabled = 0;
+    netsio_netstream_recalc();
     send_to_fujinet(&pkt, 1);
     return 0;
 }
@@ -595,6 +684,7 @@ static void *fujinet_rx_thread(void *arg) {
                 Log_print("netsio: recv: device connected");
 #endif
                 netsio_enabled = 1;
+                netsio_netstream_recalc();
                 break;
             }
 
@@ -604,6 +694,9 @@ static void *fujinet_rx_thread(void *arg) {
                 Log_print("netsio: recv: device disconnected");
 #endif
                 netsio_enabled = 0;
+                netsio_netstream_pending_enable = 0;
+                netsio_netstream_fuji_enabled = 0;
+                netsio_netstream_is_active = 0;
                 break;
             }
             
@@ -826,6 +919,11 @@ void netsio_shutdown(void) {
     netsio_sync_wait = 0;
     netsio_cmd_state = 0;
     netsio_next_write_size = 0;
+    netsio_netstream_pending_enable = 0;
+    netsio_netstream_fuji_enabled = 0;
+    netsio_netstream_motor_on = 0;
+    netsio_netstream_pokey_ok = 0;
+    netsio_netstream_is_active = 0;
 
     /* Clear address info */
     memset(&fujinet_addr, 0, sizeof(fujinet_addr));

--- a/src/netsio.c
+++ b/src/netsio.c
@@ -240,6 +240,7 @@ int netsio_init(uint16_t port) {
     struct sockaddr_in addr;
     pthread_t rx_thread;
     int broadcast = 1;
+    int reuse = 1;
 
     /* Skip re-initialization if already initialized (during emulator restarts) */
     if (netsio_initialized) {
@@ -296,7 +297,6 @@ int netsio_init(uint16_t port) {
     }
 
     /* Enable SO_REUSEADDR to allow binding even if the port is in TIME_WAIT state */
-    int reuse = 1;
     if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
     {
 #ifdef DEBUG

--- a/src/netsio.h
+++ b/src/netsio.h
@@ -91,4 +91,12 @@ int netsio_warm_reset(void);
 
 void netsio_test_cmd(void);
 
+/* Netstream state gates (Fuji $70/$F0 + MOTOR + POKEY config). */
+void netsio_netstream_set_motor(int motor_on);
+void netsio_netstream_note_command_frame(const uint8_t *cmd, size_t len);
+void netsio_netstream_note_status_byte(uint8_t status);
+void netsio_netstream_clear_pending(void);
+void netsio_netstream_update_pokey(uint8_t skctl, uint8_t audctl, uint8_t audf3, uint8_t audf4);
+int netsio_netstream_active(void);
+
 #endif /* NETSIO_H */

--- a/src/pia.c
+++ b/src/pia.c
@@ -101,12 +101,7 @@ static void set_CA2(int value)
 		/* The motor status has changed */
 		CASSETTE_TapeMotor(!value);
 #ifdef NETSIO
-		if (netsio_enabled) {
-			if (value == 0)
-				netsio_motor_on();
-			else
-				netsio_motor_off();
-		}
+		netsio_netstream_set_motor(value == 0);
 #endif
 	}
 	PIA_CA2 = value;

--- a/src/pokey.c
+++ b/src/pokey.c
@@ -217,6 +217,9 @@ void POKEY_PutByte(UWORD addr, UBYTE byte)
 
 		Update_Counter((1 << POKEY_CHAN1) | (1 << POKEY_CHAN2) | (1 << POKEY_CHAN3) | (1 << POKEY_CHAN4));
 		POKEYSND_Update(POKEY_OFFSET_AUDCTL, byte, 0, SOUND_GAIN);
+#ifdef NETSIO
+		netsio_netstream_update_pokey(POKEY_SKCTL, POKEY_AUDCTL[0], POKEY_AUDF[POKEY_CHAN3], POKEY_AUDF[POKEY_CHAN4]);
+#endif
 		break;
 	case POKEY_OFFSET_AUDF1:
 		POKEY_AUDF[POKEY_CHAN1] = byte;
@@ -232,11 +235,17 @@ void POKEY_PutByte(UWORD addr, UBYTE byte)
 		POKEY_AUDF[POKEY_CHAN3] = byte;
 		Update_Counter((POKEY_AUDCTL[0] & POKEY_CH3_CH4) ? ((1 << POKEY_CHAN4) | (1 << POKEY_CHAN3)) : (1 << POKEY_CHAN3));
 		POKEYSND_Update(POKEY_OFFSET_AUDF3, byte, 0, SOUND_GAIN);
+#ifdef NETSIO
+		netsio_netstream_update_pokey(POKEY_SKCTL, POKEY_AUDCTL[0], POKEY_AUDF[POKEY_CHAN3], POKEY_AUDF[POKEY_CHAN4]);
+#endif
 		break;
 	case POKEY_OFFSET_AUDF4:
 		POKEY_AUDF[POKEY_CHAN4] = byte;
 		Update_Counter(1 << POKEY_CHAN4);
 		POKEYSND_Update(POKEY_OFFSET_AUDF4, byte, 0, SOUND_GAIN);
+#ifdef NETSIO
+		netsio_netstream_update_pokey(POKEY_SKCTL, POKEY_AUDCTL[0], POKEY_AUDF[POKEY_CHAN3], POKEY_AUDF[POKEY_CHAN4]);
+#endif
 		break;
 	case POKEY_OFFSET_IRQEN:
 		POKEY_IRQEN = byte;
@@ -259,6 +268,12 @@ void POKEY_PutByte(UWORD addr, UBYTE byte)
 	case POKEY_OFFSET_SEROUT:
 #ifdef VOICEBOX
 		VOICEBOX_SEROUTPutByte(byte);
+#endif
+/* Netstream raw serial path: only active after Fuji enable + MOTOR + matching POKEY setup. */
+#ifdef NETSIO
+		if (netsio_enabled && netsio_netstream_active())
+			NetSIO_PutByte(byte);
+		else
 #endif
 		if ((POKEY_SKCTL & 0x70) == 0x20 && POKEY_siocheck())
 			SIO_PutByte(byte);
@@ -311,6 +326,9 @@ void POKEY_PutByte(UWORD addr, UBYTE byte)
 #endif
 		POKEY_SKCTL = byte;
 		POKEYSND_Update(POKEY_OFFSET_SKCTL, byte, 0, SOUND_GAIN);
+#ifdef NETSIO
+		netsio_netstream_update_pokey(POKEY_SKCTL, POKEY_AUDCTL[0], POKEY_AUDF[POKEY_CHAN3], POKEY_AUDF[POKEY_CHAN4]);
+#endif
 		if (byte & 4)
 			pot_scanline = 228;	/* fast pot mode - return results immediately */
 		if ((byte & 0x03) == 0) {
@@ -392,6 +410,9 @@ int POKEY_Initialise(int *argc, char *argv[])
 	POKEY_IRQEN = 0x00;
 	POKEY_SKSTAT = 0xef;
 	POKEY_SKCTL = 0x00;
+#ifdef NETSIO
+	netsio_netstream_update_pokey(POKEY_SKCTL, 0, 0, 0);
+#endif
 
 	for (i = 0; i < (POKEY_MAXPOKEYS * 4); i++) {
 		POKEY_AUDC[i] = 0;

--- a/src/sio.c
+++ b/src/sio.c
@@ -1528,6 +1528,15 @@ static UBYTE Command_Frame(void)
 /* Enable/disable the command frame */
 void SIO_SwitchCommandFrame(int onoff)
 {
+#ifdef NETSIO
+	if (netsio_enabled && netsio_netstream_active()) {
+		CommandIndex = 0;
+		DataIndex = 0;
+		ExpectedBytes = 0;
+		TransferStatus = SIO_NoFrame;
+		return;
+	}
+#endif /* NETSIO */
 	if (onoff)
 	{				/* Enabled */
 #ifdef NETSIO
@@ -1555,6 +1564,7 @@ void SIO_SwitchCommandFrame(int onoff)
 #ifdef DEBUG
 				Log_print("Short command frame: %d bytes", CommandIndex);
 #endif
+				netsio_netstream_clear_pending();
 				/* a) Send short CF ...
 				if (CommandIndex > 0)
 					netsio_send_block(CommandFrame, CommandIndex);
@@ -1618,6 +1628,7 @@ void NetSIO_PutByte(int byte)
 			CommandFrame[CommandIndex++] = byte; /* Collect CF bytes into buffer */
 			if (CommandIndex == ExpectedBytes)
 			{
+				netsio_netstream_note_command_frame(CommandFrame, ExpectedBytes);
 				netsio_send_block(CommandFrame, ExpectedBytes); /* Send CF buffer */
 			}
 		}
@@ -1757,6 +1768,7 @@ int NetSIO_GetByte(void)
 
 	switch (TransferStatus) {
 	case SIO_StatusRead:
+		netsio_netstream_note_status_byte((uint8_t)b);
 		if (b == 'A')
 		{ /* ACK received */
 			if (netsio_next_write_size > 0)


### PR DESCRIPTION
Adds FujiNet Netstream state machine/hooks in netsio/pokey/sio/pia which allows using the SIO port as a raw serial to network device.

Adds a brief wait to emulation startup for NetSIO connection to be made, otherwise you may need to perform cold reset before emulator boots from FujiNet.