### PR TITLE
Fix control-letter key handling in SDL2 to match SDL1.2

### DIFF
--- a/src/sdl/input.c
+++ b/src/sdl/input.c
@@ -1324,6 +1324,15 @@ int PLATFORM_Keyboard(void)
 	if (key_control) {
 		if (lastuni == 0 && lastkey >= SDLK_a && lastkey <= SDLK_z)
 			lastuni = lastkey - SDLK_a + 1;
+		/* lastuni is set 0 only in SDL2 even when Ctrl key
+		   is pressed along with another key but we know that
+		   the control key is currently down so we set lastuni
+		   to the ASCII equivalent for control code (1-26)
+		   only for alpha keys so that they can be handled
+		   properly below.
+		   in SDL1.2, lastuni is set properly already, so it
+		   will have a non-zero value.
+		*/
 		switch(lastuni) {
 		case '.':
 			return AKEY_FULLSTOP|shiftctrl;

--- a/src/sdl/input.c
+++ b/src/sdl/input.c
@@ -1322,6 +1322,8 @@ int PLATFORM_Keyboard(void)
 
 	/* Handle CTRL-0 to CTRL-9 and other control characters */
 	if (key_control) {
+		if (lastuni == 0 && lastkey >= SDLK_a && lastkey <= SDLK_z)
+			lastuni = lastkey - SDLK_a + 1;
 		switch(lastuni) {
 		case '.':
 			return AKEY_FULLSTOP|shiftctrl;


### PR DESCRIPTION
Key handling of control-letter combinations were not properly handled when compiling with SDL2, but were working in SDL1.2.  Changes in input and key press handling from SDL1.2 to SDL2.0 resulted in a difference in returned values for keycodes/scancodes. The value of lastuni was not being passed properly when in SDL2.0. This patch fixes that.

Test compiled:  --with-video=sdl and --with-video=sdl2
Manually tested both builds to determine if keypress behavior for control-key combinations in both builds matched.