### PR TITLE
netsio fixes for modem, high speed, write_size bug fix. and BASIC Disable fix

### DIFF
--- a/src/netsio.c
+++ b/src/netsio.c
@@ -63,6 +63,8 @@ static socklen_t fujinet_addr_len = sizeof(fujinet_addr);
 
 /* Thread declaration */
 static void *fujinet_rx_thread(void *arg);
+static pthread_mutex_t netsio_sync_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t netsio_sync_cond = PTHREAD_COND_INITIALIZER;
 
 static void netsio_netstream_recalc(void)
 {
@@ -81,17 +83,6 @@ static void netsio_netstream_recalc(void)
             netsio_netstream_motor_on,
             netsio_netstream_pokey_ok);
 #endif
-    }
-}
-
-static void millisleep(unsigned int ms)
-{
-    struct timespec req, rem;
-    req.tv_sec  = ms / 1000;
-    req.tv_nsec = (long)(ms % 1000) * 1000000L;
-
-    while (nanosleep(&req, &rem) == -1 && errno == EINTR) {
-        req = rem;
     }
 }
 
@@ -346,20 +337,26 @@ int netsio_init(uint16_t port) {
 /* Called when a command frame with sync response is sent to FujiNet */
 void netsio_wait_for_sync(void)
 {
-    int ticker = 0;
-    while (netsio_sync_wait)
-    {
+    struct timespec deadline;
+
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_nsec += 40 * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec += deadline.tv_nsec / 1000000000L;
+        deadline.tv_nsec %= 1000000000L;
+    }
+
+    pthread_mutex_lock(&netsio_sync_mutex);
+    while (netsio_sync_wait) {
 #ifdef DEBUG
-        Log_print("netsio: waiting for sync response - %d", ticker);
+        Log_print("netsio: waiting for sync response");
 #endif
-        millisleep(5);
-        if (ticker > 7)
-        {
+        if (pthread_cond_timedwait(&netsio_sync_cond, &netsio_sync_mutex, &deadline) == ETIMEDOUT) {
             netsio_sync_wait = 0;
             break;
         }
-        ticker++;
     }
+    pthread_mutex_unlock(&netsio_sync_mutex);
 }
 
 /* Return number of bytes waiting from FujiNet to emulator */
@@ -407,6 +404,9 @@ int netsio_cmd_off(void)
 int netsio_cmd_off_sync(void)
 {
     uint8_t p[2];
+    pthread_mutex_lock(&netsio_sync_mutex);
+    netsio_sync_wait = 1; /* pause emulation until we hear back or timeout */
+    pthread_mutex_unlock(&netsio_sync_mutex);
     p[0] = NETSIO_COMMAND_OFF_SYNC;
     netsio_sync_num++;
     p[1] = netsio_sync_num;
@@ -414,7 +414,6 @@ int netsio_cmd_off_sync(void)
     Log_print("netsio: CMD OFF SYNC");
 #endif
     send_to_fujinet(p, sizeof(p));
-    netsio_sync_wait = 1; /* pause emulation until we hear back or timeout */
     return 0;
 }
 
@@ -542,6 +541,9 @@ int netsio_send_block(const uint8_t *block, ssize_t len) {
 int netsio_send_byte_sync(uint8_t b)
 {
     uint8_t p[3];
+    pthread_mutex_lock(&netsio_sync_mutex);
+    netsio_sync_wait = 1; /* pause emulation until we hear back or timeout s*/
+    pthread_mutex_unlock(&netsio_sync_mutex);
     p[0] = NETSIO_DATA_BYTE_SYNC;
     p[1] = b;
     netsio_sync_num++;
@@ -550,7 +552,6 @@ int netsio_send_byte_sync(uint8_t b)
     Log_print("netsio: send byte: 0x%02X sync: %d", b, netsio_sync_num);
 #endif
     send_to_fujinet(p, sizeof(p));
-    netsio_sync_wait = 1; /* pause emulation until we hear back or timeout s*/
     return 0;
 }
 
@@ -797,7 +798,10 @@ static void *fujinet_rx_thread(void *arg) {
 #endif
                     }
                 }
+                pthread_mutex_lock(&netsio_sync_mutex);
                 netsio_sync_wait = 0; /* continue emulation */
+                pthread_cond_broadcast(&netsio_sync_cond);
+                pthread_mutex_unlock(&netsio_sync_mutex);
                 break;
             }
 
@@ -916,7 +920,10 @@ void netsio_shutdown(void) {
     netsio_initialized = 0;  /* Allow re-initialization after shutdown */
     netsio_sync_num = 0;
     fujinet_known = 0;
+    pthread_mutex_lock(&netsio_sync_mutex);
     netsio_sync_wait = 0;
+    pthread_cond_broadcast(&netsio_sync_cond);
+    pthread_mutex_unlock(&netsio_sync_mutex);
     netsio_cmd_state = 0;
     netsio_next_write_size = 0;
     netsio_netstream_pending_enable = 0;

--- a/src/netsio.c
+++ b/src/netsio.c
@@ -755,7 +755,8 @@ static void *fujinet_rx_thread(void *arg) {
             case NETSIO_SYNC_RESPONSE:
             {
                 /* packet: [cmd][sync#][ack_type][ack_byte][write_lo][write_hi] */
-                uint8_t resp_sync, ack_type, ack_byte, write_size;
+                uint8_t resp_sync, ack_type, ack_byte;
+                uint16_t write_size;
 
                 if (n < 6)
                 {

--- a/src/pokey.c
+++ b/src/pokey.c
@@ -174,6 +174,19 @@ static int POKEY_siocheck(void)
 		&& (POKEY_AUDCTL[0] & 0x28) == 0x28;
 }
 
+#ifdef NETSIO
+static int POKEY_serial_byte_delay(void)
+{
+	int divisor = POKEY_AUDF[POKEY_CHAN3];
+
+	if (divisor <= 0)
+		divisor = 1;
+
+	/* Match the existing SIO byte timing formula instead of forcing 19200 baud. */
+	return ((SIO_SERIN_INTERVAL * divisor - 1) / 0x28 + 1);
+}
+#endif /* NETSIO */
+
 #ifndef SOUND_GAIN /* sound gain can be pre-defined in the configure/Makefile */
 #define SOUND_GAIN 4
 #endif
@@ -290,10 +303,17 @@ void POKEY_PutByte(UWORD addr, UBYTE byte)
 
 		/* check if cassette 2-tone mode has been enabled */
 		if ((POKEY_SKCTL & 0x08) == 0x00) {
+#ifdef NETSIO
+			/* Use the active serial divisor for modem/netstream timing. */
+			POKEY_DELAYED_SEROUT_IRQ = POKEY_serial_byte_delay();
+			POKEY_IRQST |= 0x08;
+			POKEY_DELAYED_XMTDONE_IRQ = POKEY_DELAYED_SEROUT_IRQ * 2 - 1;
+#else
 			/* intelligent device */
 			POKEY_DELAYED_SEROUT_IRQ = SIO_SEROUT_INTERVAL;
 			POKEY_IRQST |= 0x08;
 			POKEY_DELAYED_XMTDONE_IRQ = SIO_XMTDONE_INTERVAL;
+#endif /* NETSIO */
 		}
 		else {
 			/* cassette */
@@ -511,43 +531,45 @@ void POKEY_Scanline(void)
 
 	if (POKEY_DELAYED_SERIN_IRQ > 0) {
 		if (--POKEY_DELAYED_SERIN_IRQ == 0) {
-			/* Load a byte to SERIN - even when the IRQ is disabled. */
-			POKEY_SERIN = SIO_GetByte();
-			if (POKEY_IRQEN & 0x20) {
-				if (POKEY_IRQST & 0x20) {
-					POKEY_IRQST &= 0xdf;
-#ifdef DEBUG2
-					printf("SERIO: SERIN Interrupt triggered, bytevalue %02x\n", POKEY_SERIN);
+#ifdef NETSIO
+			/* Preserve FIFO ordering: don't overwrite SERIN while the previous byte is still pending. */
+			if (netsio_enabled && !(POKEY_IRQST & 0x20) && netsio_available() > 0) {
+				POKEY_DELAYED_SERIN_IRQ = 1;
+			}
+			else
 #endif
+			{
+				/* Load a byte to SERIN - even when the IRQ is disabled. */
+				POKEY_SERIN = SIO_GetByte();
+				if (POKEY_IRQEN & 0x20) {
+					if (POKEY_IRQST & 0x20) {
+						POKEY_IRQST &= 0xdf;
+#ifdef DEBUG2
+						printf("SERIO: SERIN Interrupt triggered, bytevalue %02x\n", POKEY_SERIN);
+#endif
+					}
+					else {
+						POKEY_SKSTAT &= 0xdf;
+#ifdef DEBUG2
+						printf("SERIO: SERIN Interrupt triggered, bytevalue %02x\n", POKEY_SERIN);
+#endif
+					}
+					CPU_GenerateIRQ();
 				}
+#ifdef DEBUG2
 				else {
-					POKEY_SKSTAT &= 0xdf;
-#ifdef DEBUG2
-					printf("SERIO: SERIN Interrupt triggered, bytevalue %02x\n", POKEY_SERIN);
-#endif
+					printf("SERIO: SERIN Interrupt missed, bytevalue %02x\n", POKEY_SERIN);
 				}
-				CPU_GenerateIRQ();
-			}
-#ifdef DEBUG2
-			else {
-				printf("SERIO: SERIN Interrupt missed, bytevalue %02x\n", POKEY_SERIN);
-			}
 #endif
+			}
 		}
 	}
 #ifdef NETSIO
 	/* Check NetSIO for pending Rx bytes */
-	if (netsio_enabled && POKEY_DELAYED_SERIN_IRQ == 0) {
+	if (netsio_enabled && POKEY_DELAYED_SERIN_IRQ == 0 && (POKEY_IRQST & 0x20)) {
 		int avail = netsio_available();
 		if (avail > 0) {
-			/* TODO make various SIO speeds working
-			 * currently the POKEY_DELAYED_SERIN_IRQ is set to the same values ignoring the actual speed
-			 * and forcing baud rate to 19200
-			 */
-			if (avail == 1)
-				POKEY_DELAYED_SERIN_IRQ = SIO_SERIN_INTERVAL * 2 + 4;
-			else
-			 	POKEY_DELAYED_SERIN_IRQ = SIO_SERIN_INTERVAL + 2;
+			POKEY_DELAYED_SERIN_IRQ = POKEY_serial_byte_delay();
 		}
 	}
 #endif /* NETSIO */

--- a/src/pokey.c
+++ b/src/pokey.c
@@ -167,11 +167,19 @@ static void Update_Counter(int chan_mask);
 
 static int POKEY_siocheck(void)
 {
-	return (((POKEY_AUDF[POKEY_CHAN3] == 0x28 || POKEY_AUDF[POKEY_CHAN3] == 0x10
-	        || POKEY_AUDF[POKEY_CHAN3] == 0x08 || POKEY_AUDF[POKEY_CHAN3] == 0x0a)
-		&& POKEY_AUDF[POKEY_CHAN4] == 0x00) /* intelligent peripherals speeds */
+	int intelligent_peripheral_speed =
+		((POKEY_AUDF[POKEY_CHAN3] == 0x28 || POKEY_AUDF[POKEY_CHAN3] == 0x10
+		  || POKEY_AUDF[POKEY_CHAN3] == 0x08 || POKEY_AUDF[POKEY_CHAN3] == 0x0a)
+		 && POKEY_AUDF[POKEY_CHAN4] == 0x00);
+#ifdef NETSIO
+	if (netsio_enabled && POKEY_AUDF[POKEY_CHAN3] > 0x00 && POKEY_AUDF[POKEY_CHAN3] <= 0x28
+	 && POKEY_AUDF[POKEY_CHAN4] == 0x00)
+		intelligent_peripheral_speed = 1;
+#endif /* NETSIO */
+
+	return ((intelligent_peripheral_speed
 		|| (POKEY_SKCTL & 0x78) == 0x28) /* cassette save mode */
-		&& (POKEY_AUDCTL[0] & 0x28) == 0x28;
+		&& (POKEY_AUDCTL[0] & 0x28) == 0x28);
 }
 
 #ifdef NETSIO


### PR DESCRIPTION
* netsio: make write_size uint16 instead of incorrect uint8
* Fix BASIC disable for OS-initiated XL/XE coldstarts
  * This is needed for Atari side programs that may JMP $E477 (like FujiNet CONFIG does) to restart after mounting disks. It will correctly disable BASIC if the atari800 option is set.
* netsio: fix high speed down to divisor 1
  * event driven netsio_wait_sync instead of sleep delaying
  * netsio gated extra POKEY_siocheck values
* netsio: fix modem serial timing


Side note, I've been working on another project which these fixes were implemented for (in addition to just regular PC use)... a new Android emulator based on atari800 with fujinet-pc: https://github.com/mozzwald/fujinet-go-800
I had made some attempts to get the existing Android emulator updated and building with more modern Android but failed so I started from scratch. 