### PR TITLE
[netsio] allow loading binary using -run filename.xex at same time as…

### DIFF
--- a/src/sio.c
+++ b/src/sio.c
@@ -1683,7 +1683,7 @@ void NetSIO_PutByte(int byte)
 void SIO_PutByte(int byte)
 {
 #ifdef NETSIO
-	if (netsio_enabled)
+	if (netsio_enabled && !BINLOAD_start_binloading)
 	{
 		NetSIO_PutByte(byte);
 		return;
@@ -1844,7 +1844,7 @@ int SIO_GetByte(void)
 	int byte = 0;
 
 #ifdef NETSIO
-	if (netsio_enabled)
+	if (netsio_enabled && !BINLOAD_start_binloading)
 		return NetSIO_GetByte();
 #endif /* NETSIO */
 


### PR DESCRIPTION
This patch permits the user to use the -run command at the same time as -netsio.

e.g.
```atari800 -run fnchat.xex -netsio```

This will run the emulator, loading fnchat.xex, while enabling netsio with fujinet-pc. 